### PR TITLE
fix: ios snap behaviour

### DIFF
--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -668,7 +668,6 @@ const createCollapsibleTabs = <
       <AnimatedFlatList
         // @ts-ignore
         ref={refMap[name]}
-        bounces={false}
         bouncesZoom={false}
         style={[_style, style]}
         contentContainerStyle={[

--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -215,7 +215,8 @@ const createCollapsibleTabs = <
             }
           }
         }
-      }
+      },
+      []
     )
 
     const renderItem = React.useCallback(


### PR DESCRIPTION
On iOS, `onMomentumEnd` is not called unless the user is scrolling with momentum.

This ensures that the snap logic is called properly when momentum scrolling is not in use.

Additionally, it reenables overscroll/bouncing the scroll view.

Fixes #59 