### PR TITLE
fix: handle scroll to top ios

### DIFF
--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -102,7 +102,7 @@ const createCollapsibleTabs = <T extends ParamList>() => {
       const [headerHeight, setHeaderHeight] = React.useState<
         number | undefined
       >(initialHeaderHeight)
-      const isScrolling = useSharedValue(false)
+      const isScrolling = useSharedValue(0)
       const scrollYCurrent = useSharedValue(0)
       const scrollY = useSharedValue(React.Children.map(children, () => 0))
       const offset = useSharedValue(0)
@@ -623,15 +623,24 @@ const createCollapsibleTabs = <T extends ParamList>() => {
             scrollY.value[index.value] = y
             oldAccScrollY.value = accScrollY.value
             accScrollY.value = scrollY.value[index.value] + offset.value
+
+            isScrolling.value = 1
+
+            // cancel the animation that is setting this back to 0 if we're still scrolling
+            cancelAnimation(isScrolling)
+
+            // set it back to 0 after a few frames without active scrolling
+            isScrolling.value = withDelay(
+              ONE_FRAME_MS * 3,
+              withTiming(0, { duration: 0 })
+            )
           }
         },
         onBeginDrag: () => {
-          isScrolling.value = true
           endDrag.value = 0
         },
         onEndDrag: () => {
           isGliding.value = true
-          isScrolling.value = false
           if (Platform.OS === 'ios') {
             endDrag.value = 1
             endDrag.value = withDelay(

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export type ContextType<T extends ParamList> = {
   oldAccScrollY: Animated.SharedValue<number>
   accScrollY: Animated.SharedValue<number>
   offset: Animated.SharedValue<number>
-  isScrolling: Animated.SharedValue<boolean>
+  isScrolling: Animated.SharedValue<number>
   focusedTab: Animated.SharedValue<T>
   accDiffClamp: Animated.SharedValue<number>
   containerHeight?: number


### PR DESCRIPTION
Fixes #66 

Open for discussion. I didn't notice any breakage from doing it this way.

The idea behind it is that if we detect `onScroll` being called, then we set `isScrolling` to `1`. Once `onScroll` stops firing then it is set back to `0`.

This has the benefit and side effect that other types of scroll besides those initiated by `onBeginDrag` are handled by default (such as programatic scrolls)