### PR TITLE
feat: add support for collpased header height

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ const styles = StyleSheet.create({
 })
 
 export default Example
-
 ```
 
 # Guides
@@ -200,17 +199,18 @@ const {
 ```
 
 or
+
 ```tsx
 const { useTabsContext, , ...Tabs } = createCollapsibleTabs<MyTabs>()
 ```
 
 use like this:
+
 ```tsx
 <Tabs.Container {...props} />
 <Tabs.FlatList {...props} />
 <Tabs.ScrollView {...props} />
 ```
-
 
 ### Tabs.Container
 
@@ -253,26 +253,26 @@ const Example: React.FC<Props> = () => {
 
 #### Props
 
-|name|type|default|description|
-|:----:|:----:|:----:|:----:|
-|HeaderComponent|`((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined`|||
-|TabBarComponent|`((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined`|`null`||
-|cancelLazyFadeIn|`boolean \| undefined`|||
-|cancelTranslation|`boolean \| undefined`|||
-|containerRef|`RefObject<ContainerRef>`|||
-|containerStyle|`StyleProp<ViewStyle>`|||
-|diffClampEnabled|`boolean \| undefined`|`false`||
-|headerContainerStyle|`StyleProp<AnimateStyle<ViewStyle>>`|||
-|headerHeight|`number \| undefined`||Is optional, but will optimize the first render.|
-|initialTabName|`string \| undefined`|||
-|lazy|`boolean \| undefined`||If lazy, will mount the screens only when the tab is visited. There is a default fade in transition.|
-|onIndexChange|`OnTabChangeCallback<string> \| undefined`||Callback fired when the index changes. It receives the previous and current index and tabnames.|
-|pagerProps|`Pick<FlatListProps<number>, "ItemSeparatorComponent" \| "ListEmptyComponent" \| "ListFooterComponent" \| "ListFooterComponentStyle" \| "ListHeaderComponent" \| ... 129 more ... \| "persistentScrollbar"> \| undefined`||Props passed to the horiztontal flatlist. If you want for example to disable swiping, you can pass `{ scrollEnabled: false }`|
-|refMap|`Record<string, Ref>`|||
-|snapEnabled|`boolean \| undefined`|`false`||
-|snapThreshold|`number \| undefined`|`0.5`|Percentage of header height to make the snap effect. A number between 0 and 1.|
-|tabBarHeight|`number \| undefined`||Is optional, but will optimize the first render.|
-
+|         name         |                                                                                                                type                                                                                                                | default |                                                          description                                                          |
+| :------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------------------: |
+|   HeaderComponent    | `((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` |         |                                                                                                                               |
+|   TabBarComponent    | `((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` | `null`  |                                                                                                                               |
+|   cancelLazyFadeIn   |                                                                                                       `boolean \| undefined`                                                                                                       |         |                                                                                                                               |
+|  cancelTranslation   |                                                                                                       `boolean \| undefined`                                                                                                       |         |                                                                                                                               |
+|     containerRef     |                                                                                                     `RefObject<ContainerRef>`                                                                                                      |         |                                                                                                                               |
+|    containerStyle    |                                                                                                       `StyleProp<ViewStyle>`                                                                                                       |         |                                                                                                                               |
+|   diffClampEnabled   |                                                                                                       `boolean \| undefined`                                                                                                       | `false` |                                                                                                                               |
+| headerContainerStyle |                                                                                                `StyleProp<AnimateStyle<ViewStyle>>`                                                                                                |         |                                                                                                                               |
+|     headerHeight     |                                                                                                       `number \| undefined`                                                                                                        |         |                                       Is optional, but will optimize the first render.                                        |
+|    initialTabName    |                                                                                                       `string \| undefined`                                                                                                        |         |                                                                                                                               |
+|         lazy         |                                                                                                       `boolean \| undefined`                                                                                                       |         |             If lazy, will mount the screens only when the tab is visited. There is a default fade in transition.              |
+|   minHeaderHeight    |                                                                                                       `number \| undefined`                                                                                                        |   `0`   |                                             Header minimum height when collapsed                                              |
+|    onIndexChange     |                                                                                             `OnTabChangeCallback<string> \| undefined`                                                                                             |         |                Callback fired when the index changes. It receives the previous and current index and tabnames.                |
+|      pagerProps      |     `Pick<FlatListProps<number>, "ItemSeparatorComponent" \| "ListEmptyComponent" \| "ListFooterComponent" \| "ListFooterComponentStyle" \| "ListHeaderComponent" \| ... 129 more ... \| "persistentScrollbar"> \| undefined`      |         | Props passed to the horiztontal flatlist. If you want for example to disable swiping, you can pass `{ scrollEnabled: false }` |
+|        refMap        |                                                                                                       `Record<string, Ref>`                                                                                                        |         |                                                                                                                               |
+|     snapEnabled      |                                                                                                       `boolean \| undefined`                                                                                                       | `false` |                                                                                                                               |
+|    snapThreshold     |                                                                                                       `number \| undefined`                                                                                                        |  `0.5`  |                        Percentage of header height to make the snap effect. A number between 0 and 1.                         |
+|     tabBarHeight     |                                                                                                       `number \| undefined`                                                                                                        |         |                                       Is optional, but will optimize the first render.                                        |
 
 ### Tabs.Lazy
 
@@ -280,21 +280,18 @@ Typically used internally, but if you want to mix lazy and regular screens you c
 
 #### Props
 
-|name|type|
-|:----:|:----:|
-|cancelLazyFadeIn|`boolean \| undefined`|
-|startMounted|`boolean \| undefined`|
-
+|       name       |          type          |
+| :--------------: | :--------------------: |
+| cancelLazyFadeIn | `boolean \| undefined` |
+|   startMounted   | `boolean \| undefined` |
 
 ### Tabs.FlatList
 
 Use like a regular flatlist.
 
-
 ### Tabs.ScrollView
 
 Use like a regular scrollview.
-
 
 ### useTabsContext
 
@@ -306,32 +303,32 @@ const { focusedTab, ...rest } = useTabsContext()
 
 #### Values
 
-|name|type|default|description|
-|:----:|:----:|:----:|:----:|
-|accDiffClamp|`SharedValue<number>`|||
-|accScrollY|`SharedValue<number>`|||
-|containerHeight|`number \| undefined`|||
-|diffClampEnabled|`boolean`|`false`||
-|endDrag|`SharedValue<number>`||Used internally.|
-|focusedTab|`SharedValue<string>`||Name of the current focused tab.|
-|headerHeight|`number`|||
-|index|`SharedValue<number>`|||
-|indexDecimal|`SharedValue<number>`|||
-|isGliding|`SharedValue<boolean>`|||
-|isScrolling|`SharedValue<number>`|||
-|isSnapping|`SharedValue<boolean>`|||
-|offset|`SharedValue<number>`|||
-|oldAccScrollY|`SharedValue<number>`|||
-|refMap|`Record<string, Ref>`|||
-|scrollX|`SharedValue<number>`||Scroll x position of the tabs container.|
-|scrollY|`SharedValue<number[]>`|||
-|scrollYCurrent|`SharedValue<number>`||Scroll position of current tab.|
-|snapEnabled|`boolean`|`false`||
-|snapThreshold|`number`|`0.5`||
-|snappingTo|`SharedValue<number>`||Used internally.|
-|tabBarHeight|`number`|||
-|tabNames|`SharedValue<string[]>`||Tab names, same as the keys of `refMap`.|
-
+|         name         |          type           | default |               description                |
+| :------------------: | :---------------------: | :-----: | :--------------------------------------: |
+|     accDiffClamp     |  `SharedValue<number>`  |         |                                          |
+|      accScrollY      |  `SharedValue<number>`  |         |                                          |
+|   containerHeight    |  `number \| undefined`  |         |                                          |
+|   diffClampEnabled   |        `boolean`        | `false` |                                          |
+|       endDrag        |  `SharedValue<number>`  |         |             Used internally.             |
+|      focusedTab      |  `SharedValue<string>`  |         |     Name of the current focused tab.     |
+|     headerHeight     |        `number`         |         |                                          |
+| headerScrollDistance |  `SharedValue<number>`  |         |                                          |
+|        index         |  `SharedValue<number>`  |         |                                          |
+|     indexDecimal     |  `SharedValue<number>`  |         |                                          |
+|      isGliding       | `SharedValue<boolean>`  |         |                                          |
+|     isScrolling      |  `SharedValue<number>`  |         |                                          |
+|      isSnapping      | `SharedValue<boolean>`  |         |                                          |
+|        offset        |  `SharedValue<number>`  |         |                                          |
+|    oldAccScrollY     |  `SharedValue<number>`  |         |                                          |
+|        refMap        |  `Record<string, Ref>`  |         |                                          |
+|       scrollX        |  `SharedValue<number>`  |         | Scroll x position of the tabs container. |
+|       scrollY        | `SharedValue<number[]>` |         |                                          |
+|    scrollYCurrent    |  `SharedValue<number>`  |         |     Scroll position of current tab.      |
+|     snapEnabled      |        `boolean`        | `false` |                                          |
+|    snapThreshold     |        `number`         |  `0.5`  |                                          |
+|      snappingTo      |  `SharedValue<number>`  |         |             Used internally.             |
+|     tabBarHeight     |        `number`         |         |                                          |
+|       tabNames       | `SharedValue<string[]>` |         | Tab names, same as the keys of `refMap`. |
 
 ### useCollapsibleStyle
 
@@ -341,13 +338,11 @@ You can use this to get the progessViewOffset and pass to the refresh control of
 
 #### Values
 
-|name|type|
-|:----:|:----:|
-|contentContainerStyle|`{ minHeight: number; paddingTop: number; }`|
-|progressViewOffset|`number`|
-|style|`{ width: number; }`|
-
-
+|         name          |                     type                     |
+| :-------------------: | :------------------------------------------: |
+| contentContainerStyle | `{ minHeight: number; paddingTop: number; }` |
+|  progressViewOffset   |                   `number`                   |
+|         style         |             `{ width: number; }`             |
 
 ## Default Tab Bar
 
@@ -355,20 +350,19 @@ You can use this to get the progessViewOffset and pass to the refresh control of
 
 #### Props
 
-|name|type|default|
-|:----:|:----:|:----:|
-|TabItemComponent|`((props: MaterialTabItemProps<any>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined`|`null`|
-|containerRef|`RefObject<ContainerRef>`||
-|focusedTab|`SharedValue<any>`||
-|getLabelText|`((name: any) => string) \| undefined`|`(name) => name.toUpperCase()`|
-|index|`SharedValue<number>`||
-|indexDecimal|`SharedValue<number>`||
-|indicatorStyle|`StyleProp<AnimateStyle<ViewStyle>>`||
-|onTabPress|`(name: any) => void`||
-|refMap|`Record<any, Ref>`||
-|scrollEnabled|`boolean \| undefined`|`false`|
-|style|`StyleProp<ViewStyle>`||
-
+|       name       |                                                                                                                   type                                                                                                                   |            default             |
+| :--------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------: |
+| TabItemComponent | `((props: MaterialTabItemProps<any>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` |             `null`             |
+|   containerRef   |                                                                                                        `RefObject<ContainerRef>`                                                                                                         |                                |
+|    focusedTab    |                                                                                                            `SharedValue<any>`                                                                                                            |                                |
+|   getLabelText   |                                                                                                  `((name: any) => string) \| undefined`                                                                                                  | `(name) => name.toUpperCase()` |
+|      index       |                                                                                                          `SharedValue<number>`                                                                                                           |                                |
+|   indexDecimal   |                                                                                                          `SharedValue<number>`                                                                                                           |                                |
+|  indicatorStyle  |                                                                                                   `StyleProp<AnimateStyle<ViewStyle>>`                                                                                                   |                                |
+|    onTabPress    |                                                                                                          `(name: any) => void`                                                                                                           |                                |
+|      refMap      |                                                                                                            `Record<any, Ref>`                                                                                                            |                                |
+|  scrollEnabled   |                                                                                                          `boolean \| undefined`                                                                                                          |            `false`             |
+|      style       |                                                                                                          `StyleProp<ViewStyle>`                                                                                                          |                                |
 
 ### MaterialTabItem
 
@@ -376,24 +370,21 @@ Any additional props are passed to the pressable component.
 
 #### Props
 
-|name|type|default|description|
-|:----:|:----:|:----:|:----:|
-|ItemElement|`((props: { name: any; indexDecimal: SharedValue<number>; }) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)> \| null) \| (new (props: { ...; }) => Component<...>) \| undefined`|||
-|inactiveOpacity|`number \| undefined`|`0.7`||
-|index|`number`|||
-|indexDecimal|`SharedValue<number>`|||
-|label|`string`|||
-|labelStyle|`StyleProp<AnimateStyle<TextStyle>>`|||
-|name|`any`|||
-|onLayout|`(((event: LayoutChangeEvent) => void) & ((event: LayoutChangeEvent) => void)) \| undefined`||Invoked on mount and layout changes with {nativeEvent: { layout: {x, y, width, height}}}.|
-|onPress|`(name: any) => void`|||
-|pressColor|`string \| undefined`|`#DDDDDD`||
-|pressOpacity|`number \| undefined`|`Platform.OS === 'ios' ? 0.2 : 1`||
-|scrollEnabled|`boolean \| undefined`|||
-|style|`ViewStyle \| (ViewStyle & false) \| (ViewStyle & number & { __registeredStyleBrand: ViewStyle; }) \| (ViewStyle & RecursiveArray<false \| ViewStyle \| RegisteredStyle<...> \| null \| undefined>) \| (ViewStyle & ((state: Readonly<...>) => StyleProp<...>)) \| undefined`||Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.|
-
-
-
+|      name       |                                                                                                                                                         type                                                                                                                                                          |              default              |                                                               description                                                               |
+| :-------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
+|   ItemElement   | `((props: { name: any; indexDecimal: SharedValue<number>; }) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)> \| null) \| (new (props: { ...; }) => Component<...>) \| undefined` |                                   |                                                                                                                                         |
+| inactiveOpacity |                                                                                                                                                 `number \| undefined`                                                                                                                                                 |               `0.7`               |                                                                                                                                         |
+|      index      |                                                                                                                                                       `number`                                                                                                                                                        |                                   |                                                                                                                                         |
+|  indexDecimal   |                                                                                                                                                 `SharedValue<number>`                                                                                                                                                 |                                   |                                                                                                                                         |
+|      label      |                                                                                                                                                       `string`                                                                                                                                                        |                                   |                                                                                                                                         |
+|   labelStyle    |                                                                                                                                         `StyleProp<AnimateStyle<TextStyle>>`                                                                                                                                          |                                   |                                                                                                                                         |
+|      name       |                                                                                                                                                         `any`                                                                                                                                                         |                                   |                                                                                                                                         |
+|    onLayout     |                                                                                                             `(((event: LayoutChangeEvent) => void) & ((event: LayoutChangeEvent) => void)) \| undefined`                                                                                                              |                                   |                        Invoked on mount and layout changes with {nativeEvent: { layout: {x, y, width, height}}}.                        |
+|     onPress     |                                                                                                                                                 `(name: any) => void`                                                                                                                                                 |                                   |                                                                                                                                         |
+|   pressColor    |                                                                                                                                                 `string \| undefined`                                                                                                                                                 |             `#DDDDDD`             |                                                                                                                                         |
+|  pressOpacity   |                                                                                                                                                 `number \| undefined`                                                                                                                                                 | `Platform.OS === 'ios' ? 0.2 : 1` |                                                                                                                                         |
+|  scrollEnabled  |                                                                                                                                                `boolean \| undefined`                                                                                                                                                 |                                   |                                                                                                                                         |
+|      style      |                     `ViewStyle \| (ViewStyle & false) \| (ViewStyle & number & { __registeredStyleBrand: ViewStyle; }) \| (ViewStyle & RecursiveArray<false \| ViewStyle \| RegisteredStyle<...> \| null \| undefined>) \| (ViewStyle & ((state: Readonly<...>) => StyleProp<...>)) \| undefined`                     |                                   | Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles. |
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const styles = StyleSheet.create({
 })
 
 export default Example
+
 ```
 
 # Guides
@@ -199,18 +200,17 @@ const {
 ```
 
 or
-
 ```tsx
 const { useTabsContext, , ...Tabs } = createCollapsibleTabs<MyTabs>()
 ```
 
 use like this:
-
 ```tsx
 <Tabs.Container {...props} />
 <Tabs.FlatList {...props} />
 <Tabs.ScrollView {...props} />
 ```
+
 
 ### Tabs.Container
 
@@ -253,26 +253,27 @@ const Example: React.FC<Props> = () => {
 
 #### Props
 
-|         name         |                                                                                                                type                                                                                                                | default |                                                          description                                                          |
-| :------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------------------: |
-|   HeaderComponent    | `((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` |         |                                                                                                                               |
-|   TabBarComponent    | `((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` | `null`  |                                                                                                                               |
-|   cancelLazyFadeIn   |                                                                                                       `boolean \| undefined`                                                                                                       |         |                                                                                                                               |
-|  cancelTranslation   |                                                                                                       `boolean \| undefined`                                                                                                       |         |                                                                                                                               |
-|     containerRef     |                                                                                                     `RefObject<ContainerRef>`                                                                                                      |         |                                                                                                                               |
-|    containerStyle    |                                                                                                       `StyleProp<ViewStyle>`                                                                                                       |         |                                                                                                                               |
-|   diffClampEnabled   |                                                                                                       `boolean \| undefined`                                                                                                       | `false` |                                                                                                                               |
-| headerContainerStyle |                                                                                                `StyleProp<AnimateStyle<ViewStyle>>`                                                                                                |         |                                                                                                                               |
-|     headerHeight     |                                                                                                       `number \| undefined`                                                                                                        |         |                                       Is optional, but will optimize the first render.                                        |
-|    initialTabName    |                                                                                                       `string \| undefined`                                                                                                        |         |                                                                                                                               |
-|         lazy         |                                                                                                       `boolean \| undefined`                                                                                                       |         |             If lazy, will mount the screens only when the tab is visited. There is a default fade in transition.              |
-|   minHeaderHeight    |                                                                                                       `number \| undefined`                                                                                                        |   `0`   |                                             Header minimum height when collapsed                                              |
-|    onIndexChange     |                                                                                             `OnTabChangeCallback<string> \| undefined`                                                                                             |         |                Callback fired when the index changes. It receives the previous and current index and tabnames.                |
-|      pagerProps      |     `Pick<FlatListProps<number>, "ItemSeparatorComponent" \| "ListEmptyComponent" \| "ListFooterComponent" \| "ListFooterComponentStyle" \| "ListHeaderComponent" \| ... 129 more ... \| "persistentScrollbar"> \| undefined`      |         | Props passed to the horiztontal flatlist. If you want for example to disable swiping, you can pass `{ scrollEnabled: false }` |
-|        refMap        |                                                                                                       `Record<string, Ref>`                                                                                                        |         |                                                                                                                               |
-|     snapEnabled      |                                                                                                       `boolean \| undefined`                                                                                                       | `false` |                                                                                                                               |
-|    snapThreshold     |                                                                                                       `number \| undefined`                                                                                                        |  `0.5`  |                        Percentage of header height to make the snap effect. A number between 0 and 1.                         |
-|     tabBarHeight     |                                                                                                       `number \| undefined`                                                                                                        |         |                                       Is optional, but will optimize the first render.                                        |
+|name|type|default|description|
+|:----:|:----:|:----:|:----:|
+|HeaderComponent|`((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, any> \| null) \| (new (props: any) => Component<any, any, any>)>) \| undefined`|||
+|TabBarComponent|`((props: TabBarProps<string>) => ReactElement<any, string \| ((props: any) => ReactElement<any, any> \| null) \| (new (props: any) => Component<any, any, any>)>) \| undefined`|`null`||
+|cancelLazyFadeIn|`boolean \| undefined`|||
+|cancelTranslation|`boolean \| undefined`|||
+|containerRef|`RefObject<ContainerRef>`|||
+|containerStyle|`StyleProp<ViewStyle>`|||
+|diffClampEnabled|`boolean \| undefined`|`false`||
+|headerContainerStyle|`StyleProp<AnimateStyle<ViewStyle>>`|||
+|headerHeight|`number \| undefined`||Is optional, but will optimize the first render.|
+|initialTabName|`string \| undefined`|||
+|lazy|`boolean \| undefined`||If lazy, will mount the screens only when the tab is visited. There is a default fade in transition.|
+|minHeaderHeight|`number \| undefined`|`0`|Header minimum height when collapsed|
+|onIndexChange|`OnTabChangeCallback<string> \| undefined`||Callback fired when the index changes. It receives the previous and current index and tabnames.|
+|pagerProps|`Pick<FlatListProps<number>, "ItemSeparatorComponent" \| "ListEmptyComponent" \| "ListFooterComponent" \| "ListFooterComponentStyle" \| "ListHeaderComponent" \| ... 128 more ... \| "persistentScrollbar"> \| undefined`||Props passed to the horiztontal flatlist. If you want for example to disable swiping, you can pass `{ scrollEnabled: false }`|
+|refMap|`Record<string, Ref>`|||
+|snapEnabled|`boolean \| undefined`|`false`||
+|snapThreshold|`number \| undefined`|`0.5`|Percentage of header height to make the snap effect. A number between 0 and 1.|
+|tabBarHeight|`number \| undefined`||Is optional, but will optimize the first render.|
+
 
 ### Tabs.Lazy
 
@@ -280,18 +281,21 @@ Typically used internally, but if you want to mix lazy and regular screens you c
 
 #### Props
 
-|       name       |          type          |
-| :--------------: | :--------------------: |
-| cancelLazyFadeIn | `boolean \| undefined` |
-|   startMounted   | `boolean \| undefined` |
+|name|type|
+|:----:|:----:|
+|cancelLazyFadeIn|`boolean \| undefined`|
+|startMounted|`boolean \| undefined`|
+
 
 ### Tabs.FlatList
 
 Use like a regular flatlist.
 
+
 ### Tabs.ScrollView
 
 Use like a regular scrollview.
+
 
 ### useTabsContext
 
@@ -303,32 +307,33 @@ const { focusedTab, ...rest } = useTabsContext()
 
 #### Values
 
-|         name         |          type           | default |               description                |
-| :------------------: | :---------------------: | :-----: | :--------------------------------------: |
-|     accDiffClamp     |  `SharedValue<number>`  |         |                                          |
-|      accScrollY      |  `SharedValue<number>`  |         |                                          |
-|   containerHeight    |  `number \| undefined`  |         |                                          |
-|   diffClampEnabled   |        `boolean`        | `false` |                                          |
-|       endDrag        |  `SharedValue<number>`  |         |             Used internally.             |
-|      focusedTab      |  `SharedValue<string>`  |         |     Name of the current focused tab.     |
-|     headerHeight     |        `number`         |         |                                          |
-| headerScrollDistance |  `SharedValue<number>`  |         |                                          |
-|        index         |  `SharedValue<number>`  |         |                                          |
-|     indexDecimal     |  `SharedValue<number>`  |         |                                          |
-|      isGliding       | `SharedValue<boolean>`  |         |                                          |
-|     isScrolling      |  `SharedValue<number>`  |         |                                          |
-|      isSnapping      | `SharedValue<boolean>`  |         |                                          |
-|        offset        |  `SharedValue<number>`  |         |                                          |
-|    oldAccScrollY     |  `SharedValue<number>`  |         |                                          |
-|        refMap        |  `Record<string, Ref>`  |         |                                          |
-|       scrollX        |  `SharedValue<number>`  |         | Scroll x position of the tabs container. |
-|       scrollY        | `SharedValue<number[]>` |         |                                          |
-|    scrollYCurrent    |  `SharedValue<number>`  |         |     Scroll position of current tab.      |
-|     snapEnabled      |        `boolean`        | `false` |                                          |
-|    snapThreshold     |        `number`         |  `0.5`  |                                          |
-|      snappingTo      |  `SharedValue<number>`  |         |             Used internally.             |
-|     tabBarHeight     |        `number`         |         |                                          |
-|       tabNames       | `SharedValue<string[]>` |         | Tab names, same as the keys of `refMap`. |
+|name|type|default|description|
+|:----:|:----:|:----:|:----:|
+|accDiffClamp|`SharedValue<number>`|||
+|accScrollY|`SharedValue<number>`|||
+|containerHeight|`number \| undefined`|||
+|diffClampEnabled|`boolean`|`false`||
+|endDrag|`SharedValue<number>`||Used internally.|
+|focusedTab|`SharedValue<string>`||Name of the current focused tab.|
+|headerHeight|`number`|||
+|headerScrollDistance|`SharedValue<number>`|||
+|index|`SharedValue<number>`|||
+|indexDecimal|`SharedValue<number>`|||
+|isGliding|`SharedValue<boolean>`|||
+|isScrolling|`SharedValue<number>`|||
+|isSnapping|`SharedValue<boolean>`|||
+|offset|`SharedValue<number>`|||
+|oldAccScrollY|`SharedValue<number>`|||
+|refMap|`Record<string, Ref>`|||
+|scrollX|`SharedValue<number>`||Scroll x position of the tabs container.|
+|scrollY|`SharedValue<number[]>`|||
+|scrollYCurrent|`SharedValue<number>`||Scroll position of current tab.|
+|snapEnabled|`boolean`|`false`||
+|snapThreshold|`number`|`0.5`||
+|snappingTo|`SharedValue<number>`||Used internally.|
+|tabBarHeight|`number`|||
+|tabNames|`SharedValue<string[]>`||Tab names, same as the keys of `refMap`.|
+
 
 ### useCollapsibleStyle
 
@@ -338,11 +343,13 @@ You can use this to get the progessViewOffset and pass to the refresh control of
 
 #### Values
 
-|         name          |                     type                     |
-| :-------------------: | :------------------------------------------: |
-| contentContainerStyle | `{ minHeight: number; paddingTop: number; }` |
-|  progressViewOffset   |                   `number`                   |
-|         style         |             `{ width: number; }`             |
+|name|type|
+|:----:|:----:|
+|contentContainerStyle|`{ minHeight: number; paddingTop: number; }`|
+|progressViewOffset|`number`|
+|style|`{ width: number; }`|
+
+
 
 ## Default Tab Bar
 
@@ -350,19 +357,20 @@ You can use this to get the progessViewOffset and pass to the refresh control of
 
 #### Props
 
-|       name       |                                                                                                                   type                                                                                                                   |            default             |
-| :--------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------: |
-| TabItemComponent | `((props: MaterialTabItemProps<any>) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)>) \| undefined` |             `null`             |
-|   containerRef   |                                                                                                        `RefObject<ContainerRef>`                                                                                                         |                                |
-|    focusedTab    |                                                                                                            `SharedValue<any>`                                                                                                            |                                |
-|   getLabelText   |                                                                                                  `((name: any) => string) \| undefined`                                                                                                  | `(name) => name.toUpperCase()` |
-|      index       |                                                                                                          `SharedValue<number>`                                                                                                           |                                |
-|   indexDecimal   |                                                                                                          `SharedValue<number>`                                                                                                           |                                |
-|  indicatorStyle  |                                                                                                   `StyleProp<AnimateStyle<ViewStyle>>`                                                                                                   |                                |
-|    onTabPress    |                                                                                                          `(name: any) => void`                                                                                                           |                                |
-|      refMap      |                                                                                                            `Record<any, Ref>`                                                                                                            |                                |
-|  scrollEnabled   |                                                                                                          `boolean \| undefined`                                                                                                          |            `false`             |
-|      style       |                                                                                                          `StyleProp<ViewStyle>`                                                                                                          |                                |
+|name|type|default|
+|:----:|:----:|:----:|
+|TabItemComponent|`((props: MaterialTabItemProps<any>) => ReactElement<any, string \| ((props: any) => ReactElement<any, any> \| null) \| (new (props: any) => Component<any, any, any>)>) \| undefined`|`null`|
+|containerRef|`RefObject<ContainerRef>`||
+|focusedTab|`SharedValue<any>`||
+|getLabelText|`((name: any) => string) \| undefined`|`(name) => name.toUpperCase()`|
+|index|`SharedValue<number>`||
+|indexDecimal|`SharedValue<number>`||
+|indicatorStyle|`StyleProp<AnimateStyle<ViewStyle>>`||
+|onTabPress|`(name: any) => void`||
+|refMap|`Record<any, Ref>`||
+|scrollEnabled|`boolean \| undefined`|`false`|
+|style|`StyleProp<ViewStyle>`||
+
 
 ### MaterialTabItem
 
@@ -370,21 +378,24 @@ Any additional props are passed to the pressable component.
 
 #### Props
 
-|      name       |                                                                                                                                                         type                                                                                                                                                          |              default              |                                                               description                                                               |
-| :-------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
-|   ItemElement   | `((props: { name: any; indexDecimal: SharedValue<number>; }) => ReactElement<any, string \| ((props: any) => ReactElement<any, string \| ... \| (new (props: any) => Component<any, any, any>)> \| null) \| (new (props: any) => Component<...>)> \| null) \| (new (props: { ...; }) => Component<...>) \| undefined` |                                   |                                                                                                                                         |
-| inactiveOpacity |                                                                                                                                                 `number \| undefined`                                                                                                                                                 |               `0.7`               |                                                                                                                                         |
-|      index      |                                                                                                                                                       `number`                                                                                                                                                        |                                   |                                                                                                                                         |
-|  indexDecimal   |                                                                                                                                                 `SharedValue<number>`                                                                                                                                                 |                                   |                                                                                                                                         |
-|      label      |                                                                                                                                                       `string`                                                                                                                                                        |                                   |                                                                                                                                         |
-|   labelStyle    |                                                                                                                                         `StyleProp<AnimateStyle<TextStyle>>`                                                                                                                                          |                                   |                                                                                                                                         |
-|      name       |                                                                                                                                                         `any`                                                                                                                                                         |                                   |                                                                                                                                         |
-|    onLayout     |                                                                                                             `(((event: LayoutChangeEvent) => void) & ((event: LayoutChangeEvent) => void)) \| undefined`                                                                                                              |                                   |                        Invoked on mount and layout changes with {nativeEvent: { layout: {x, y, width, height}}}.                        |
-|     onPress     |                                                                                                                                                 `(name: any) => void`                                                                                                                                                 |                                   |                                                                                                                                         |
-|   pressColor    |                                                                                                                                                 `string \| undefined`                                                                                                                                                 |             `#DDDDDD`             |                                                                                                                                         |
-|  pressOpacity   |                                                                                                                                                 `number \| undefined`                                                                                                                                                 | `Platform.OS === 'ios' ? 0.2 : 1` |                                                                                                                                         |
-|  scrollEnabled  |                                                                                                                                                `boolean \| undefined`                                                                                                                                                 |                                   |                                                                                                                                         |
-|      style      |                     `ViewStyle \| (ViewStyle & false) \| (ViewStyle & number & { __registeredStyleBrand: ViewStyle; }) \| (ViewStyle & RecursiveArray<false \| ViewStyle \| RegisteredStyle<...> \| null \| undefined>) \| (ViewStyle & ((state: Readonly<...>) => StyleProp<...>)) \| undefined`                     |                                   | Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles. |
+|name|type|default|description|
+|:----:|:----:|:----:|:----:|
+|ItemElement|`((props: { name: any; indexDecimal: SharedValue<number>; }) => ReactElement<any, any> \| null) \| (new (props: { name: any; indexDecimal: SharedValue<number>; }) => Component<...>) \| undefined`|||
+|inactiveOpacity|`number \| undefined`|`0.7`||
+|index|`number`|||
+|indexDecimal|`SharedValue<number>`|||
+|label|`string`|||
+|labelStyle|`StyleProp<AnimateStyle<TextStyle>>`|||
+|name|`any`|||
+|onLayout|`(((event: LayoutChangeEvent) => void) & ((event: LayoutChangeEvent) => void)) \| undefined`||Invoked on mount and layout changes with {nativeEvent: { layout: {x, y, width, height}}}.|
+|onPress|`(name: any) => void`|||
+|pressColor|`string \| undefined`|`#DDDDDD`||
+|pressOpacity|`number \| undefined`|`Platform.OS === 'ios' ? 0.2 : 1`||
+|scrollEnabled|`boolean \| undefined`|||
+|style|`ViewStyle \| (ViewStyle & false) \| (ViewStyle & number & { __registeredStyleBrand: ViewStyle; }) \| (ViewStyle & RecursiveArray<false \| ViewStyle \| RegisteredStyle<...> \| null \| undefined>) \| (ViewStyle & ((state: PressableStateCallbackType) => StyleProp<...>)) \| undefined`||Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.|
+
+
+
 
 # Contributing
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,6 +17,7 @@ import Default from './Default'
 import DiffClamp from './DiffClamp'
 import DiffClampSnap from './DiffClampSnap'
 import Lazy from './Lazy'
+import MinHeaderHeight from './MinHeaderHeight'
 import OnIndexChange from './OnIndexChange'
 import QuickStartDemo from './QuickStartDemo'
 import Ref from './Ref'
@@ -41,6 +42,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   StartOnSpecificTab,
   Ref,
   OnIndexChange,
+  MinHeaderHeight,
 ]
 
 const ExampleList: React.FC<object> = () => {

--- a/example/src/MinHeaderHeight.tsx
+++ b/example/src/MinHeaderHeight.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import ExampleComponent from './Shared/ExampleComponent'
+import { buildHeader, HEADER_HEIGHT } from './Shared/Header'
+import { ExampleComponentType } from './types'
+
+const title = 'Min Header Height'
+
+const Header = buildHeader(title)
+const minHeaderHeight = Math.round(HEADER_HEIGHT / 3)
+
+const DefaultExample: ExampleComponentType = () => {
+  return (
+    <ExampleComponent
+      HeaderComponent={Header}
+      minHeaderHeight={minHeaderHeight}
+    />
+  )
+}
+
+DefaultExample.title = title
+
+export default DefaultExample

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,10 @@ export type CollapsibleProps<T extends ParamList> = {
    * Is optional, but will optimize the first render.
    */
   tabBarHeight?: number
+  /**
+   * Header minimum height when collapsed
+   */
+  minHeaderHeight?: number
   snapEnabled?: boolean
   diffClampEnabled?: boolean
   /**
@@ -93,6 +97,7 @@ export type CollapsibleProps<T extends ParamList> = {
 
 export type ContextType<T extends ParamList> = {
   headerHeight: number
+  headerScrollDistance: Animated.SharedValue<number>
   tabBarHeight: number
   snapEnabled: boolean
   diffClampEnabled: boolean


### PR DESCRIPTION
Hey @PedroBern, this allows to configure a height for the header when collapsed, in other words, the header will be considered collapsed once we reach, header height - collapsed height, I tested all the examples and they seem to be working properly, so I believe I got all the right variables in their place, but if you can give a new look, since you know the project/behavior better than me

Closes #5 