### PR TITLE
refactor: remove need to use any hooks

### DIFF
--- a/example/src/Shared/ExampleComponent.tsx
+++ b/example/src/Shared/ExampleComponent.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import {
   CollapsibleProps,
-  RefComponent,
-  ContainerRef,
   CollapsibleRef,
+  useContainerRef,
+  useRefMap,
 } from 'react-native-collapsible-tab-view'
-import { useAnimatedRef } from 'react-native-reanimated'
 
 import Albums from './Albums'
 import Article from './Article'
@@ -19,16 +18,8 @@ type Props = {
 
 const Example = React.forwardRef<CollapsibleRef<TabNames>, Props>(
   ({ emptyContacts, ...props }, ref) => {
-    const containerRef = useAnimatedRef<ContainerRef>()
-    const albumsRef = useAnimatedRef<RefComponent>()
-    const articleRef = useAnimatedRef<RefComponent>()
-    const contactsRef = useAnimatedRef<RefComponent>()
-
-    const [refMap] = React.useState({
-      article: articleRef,
-      albums: albumsRef,
-      contacts: contactsRef,
-    })
+    const containerRef = useContainerRef()
+    const refMap = useRefMap(['article', 'albums', 'contacts'])
 
     return (
       <Tabs.Container

--- a/example/src/Shared/ExampleComponent.tsx
+++ b/example/src/Shared/ExampleComponent.tsx
@@ -2,33 +2,22 @@ import React from 'react'
 import {
   CollapsibleProps,
   CollapsibleRef,
-  useContainerRef,
-  useRefMap,
 } from 'react-native-collapsible-tab-view'
 
 import Albums from './Albums'
 import Article from './Article'
 import Contacts from './Contacts'
 import { HEADER_HEIGHT } from './Header'
-import Tabs, { TabNames } from './Tabs'
+import Tabs, { TabNamesType } from './Tabs'
 
 type Props = {
   emptyContacts?: boolean
-} & Partial<CollapsibleProps<TabNames>>
+} & Partial<CollapsibleProps<TabNamesType>>
 
-const Example = React.forwardRef<CollapsibleRef<TabNames>, Props>(
+const Example = React.forwardRef<CollapsibleRef<TabNamesType>, Props>(
   ({ emptyContacts, ...props }, ref) => {
-    const containerRef = useContainerRef()
-    const refMap = useRefMap(['article', 'albums', 'contacts'])
-
     return (
-      <Tabs.Container
-        ref={ref}
-        containerRef={containerRef}
-        headerHeight={HEADER_HEIGHT}
-        refMap={refMap}
-        {...props}
-      >
+      <Tabs.Container ref={ref} headerHeight={HEADER_HEIGHT} {...props}>
         <Article />
         <Albums />
         <Contacts emptyContacts={emptyContacts} />

--- a/example/src/Shared/ExampleComponentScrollableTabs.tsx
+++ b/example/src/Shared/ExampleComponentScrollableTabs.tsx
@@ -2,53 +2,35 @@ import React from 'react'
 import {
   createCollapsibleTabs,
   CollapsibleProps,
-  RefComponent,
-  ContainerRef,
   MaterialTabBar,
+  useContainerRef,
+  useRefMap,
 } from 'react-native-collapsible-tab-view'
-import { useAnimatedRef } from 'react-native-reanimated'
 
 import { ArticleContent } from './Article'
 import { HEADER_HEIGHT } from './Header'
 
-type TabNames =
-  | 'screenA'
-  | 'screenB'
-  | 'screenC'
-  | 'screenD'
-  | 'screenE'
-  | 'screenF'
-  | 'screenG'
-  | 'screenH'
-  | 'screenI'
+const TabNames = [
+  'screenA',
+  'screenB',
+  'screenC',
+  'screenD',
+  'screenE',
+  'screenF',
+  'screenG',
+  'screenH',
+  'screenI',
+] as const
 
-const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNames>()
+type TabNamesType = typeof TabNames[number]
 
-type Props = Partial<CollapsibleProps<TabNames>>
+const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNamesType>()
+
+type Props = Partial<CollapsibleProps<TabNamesType>>
 
 const Example: React.FC<Props> = (props) => {
-  const containerRef = useAnimatedRef<ContainerRef>()
-  const screenARef = useAnimatedRef<RefComponent>()
-  const screenBRef = useAnimatedRef<RefComponent>()
-  const screenCRef = useAnimatedRef<RefComponent>()
-  const screenDRef = useAnimatedRef<RefComponent>()
-  const screenERef = useAnimatedRef<RefComponent>()
-  const screenFRef = useAnimatedRef<RefComponent>()
-  const screenGRef = useAnimatedRef<RefComponent>()
-  const screenHRef = useAnimatedRef<RefComponent>()
-  const screenIRef = useAnimatedRef<RefComponent>()
-
-  const [refMap] = React.useState({
-    screenA: screenARef,
-    screenB: screenBRef,
-    screenC: screenCRef,
-    screenD: screenDRef,
-    screenE: screenERef,
-    screenF: screenFRef,
-    screenG: screenGRef,
-    screenH: screenHRef,
-    screenI: screenIRef,
-  })
+  const containerRef = useContainerRef()
+  const refMap = useRefMap(TabNames)
 
   return (
     <Tabs.Container

--- a/example/src/Shared/ExampleComponentScrollableTabs.tsx
+++ b/example/src/Shared/ExampleComponentScrollableTabs.tsx
@@ -3,8 +3,6 @@ import {
   createCollapsibleTabs,
   CollapsibleProps,
   MaterialTabBar,
-  useContainerRef,
-  useRefMap,
 } from 'react-native-collapsible-tab-view'
 
 import { ArticleContent } from './Article'
@@ -24,24 +22,19 @@ const TabNames = [
 
 type TabNamesType = typeof TabNames[number]
 
-const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNamesType>()
+const { useTabsContext, ...Tabs } = createCollapsibleTabs(TabNames)
 
 type Props = Partial<CollapsibleProps<TabNamesType>>
 
 const Example: React.FC<Props> = (props) => {
-  const containerRef = useContainerRef()
-  const refMap = useRefMap(TabNames)
-
   return (
     <Tabs.Container
-      containerRef={containerRef}
       headerHeight={HEADER_HEIGHT}
-      refMap={refMap}
       lazy
       TabBarComponent={(props) => <MaterialTabBar {...props} scrollEnabled />}
       {...props}
     >
-      {Object.keys(refMap).map((name) => {
+      {TabNames.map((name) => {
         return (
           <Tabs.ScrollView key={name}>
             <ArticleContent />

--- a/example/src/Shared/QuickStartDemo.tsx
+++ b/example/src/Shared/QuickStartDemo.tsx
@@ -1,28 +1,18 @@
 import React from 'react'
 import { View, StyleSheet, ListRenderItem } from 'react-native'
-import {
-  createCollapsibleTabs,
-  useContainerRef,
-  useRefMap,
-} from 'react-native-collapsible-tab-view'
+import { createCollapsibleTabs } from 'react-native-collapsible-tab-view'
 
 const TabNames = ['A', 'B'] as const
-type TabNamesType = typeof TabNames[number]
 
-const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNamesType>()
+const { useTabsContext, ...Tabs } = createCollapsibleTabs(TabNames)
 
 const HEADER_HEIGHT = 250
 
 const Example: React.FC = () => {
-  const containerRef = useContainerRef()
-  const refMap = useRefMap(TabNames)
-
   return (
     <Tabs.Container
-      containerRef={containerRef}
       HeaderComponent={Header}
       headerHeight={HEADER_HEIGHT} // optional
-      refMap={refMap}
     >
       <ScreenA />
       <ScreenB />

--- a/example/src/Shared/QuickStartDemo.tsx
+++ b/example/src/Shared/QuickStartDemo.tsx
@@ -1,27 +1,21 @@
 import React from 'react'
 import { View, StyleSheet, ListRenderItem } from 'react-native'
 import {
-  RefComponent,
-  ContainerRef,
   createCollapsibleTabs,
+  useContainerRef,
+  useRefMap,
 } from 'react-native-collapsible-tab-view'
-import { useAnimatedRef } from 'react-native-reanimated'
 
-type TabNames = 'A' | 'B'
+const TabNames = ['A', 'B'] as const
+type TabNamesType = typeof TabNames[number]
 
-const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNames>()
+const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNamesType>()
 
 const HEADER_HEIGHT = 250
 
 const Example: React.FC = () => {
-  const containerRef = useAnimatedRef<ContainerRef>()
-  const tabARef = useAnimatedRef<RefComponent>()
-  const tabBRef = useAnimatedRef<RefComponent>()
-
-  const [refMap] = React.useState({
-    A: tabARef,
-    B: tabBRef,
-  })
+  const containerRef = useContainerRef()
+  const refMap = useRefMap(TabNames)
 
   return (
     <Tabs.Container

--- a/example/src/Shared/Tabs.tsx
+++ b/example/src/Shared/Tabs.tsx
@@ -3,13 +3,14 @@ import {
   TabBarProps as TabProps,
 } from 'react-native-collapsible-tab-view'
 
-export type TabNames = 'albums' | 'contacts' | 'article'
+export const TabNames = ['albums', 'contacts', 'article'] as const
 
-export type HeaderProps = TabProps<TabNames>
+export type TabNamesType = typeof TabNames[number]
+export type HeaderProps = TabProps<TabNamesType>
 
-export type TabBarProps = TabProps<TabNames>
+export type TabBarProps = TabProps<TabNamesType>
 
-const { useTabsContext, ...Tabs } = createCollapsibleTabs<TabNames>()
+const { useTabsContext, ...Tabs } = createCollapsibleTabs(TabNames)
 
 export default Tabs
 

--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -21,12 +21,12 @@ import Animated, {
 } from 'react-native-reanimated'
 
 import MaterialTabBar, { TABBAR_HEIGHT } from './MaterialTabBar'
+import { useContainerRef, useRefMap } from './hooks'
 import {
   CollapsibleProps,
   ContextType,
   ScrollViewProps,
   FlatListProps,
-  ParamList,
   CollapsibleRef,
   CollapsibleStyle,
 } from './types'
@@ -80,7 +80,7 @@ const init = (children: any) => {
  * <Tabs.ScrollView {...props} />
  * ```
  */
-const createCollapsibleTabs = <T extends ParamList>() => {
+const createCollapsibleTabs = <T extends string>(tabs: readonly T[]) => {
   const Context = React.createContext<ContextType<T> | undefined>(undefined)
 
   /**
@@ -153,7 +153,7 @@ const createCollapsibleTabs = <T extends ParamList>() => {
     (
       {
         initialTabName,
-        containerRef,
+        //containerRef,
         headerHeight: initialHeaderHeight,
         tabBarHeight: initialTabBarHeight = TABBAR_HEIGHT,
         snapEnabled = false,
@@ -162,7 +162,7 @@ const createCollapsibleTabs = <T extends ParamList>() => {
         children,
         HeaderComponent,
         TabBarComponent = MaterialTabBar,
-        refMap,
+        //refMap,
         headerContainerStyle,
         cancelTranslation,
         containerStyle,
@@ -173,6 +173,9 @@ const createCollapsibleTabs = <T extends ParamList>() => {
       },
       ref
     ) => {
+      const containerRef = useContainerRef()
+      const refMap = useRefMap(tabs)
+
       const windowWidth = useWindowDimensions().width
       const firstRender = React.useRef(init(children))
 

--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -1,4 +1,3 @@
-import { ParamList } from 'lib/typescript/types'
 import React from 'react'
 import {
   FlatList as RNFlatList,
@@ -30,6 +29,7 @@ import {
   FlatListProps,
   CollapsibleRef,
   CollapsibleStyle,
+  ParamList,
 } from './types'
 
 const AnimatedFlatList = Animated.createAnimatedComponent(RNFlatList)

--- a/src/createCollapsibleTabs.tsx
+++ b/src/createCollapsibleTabs.tsx
@@ -1,3 +1,4 @@
+import { ParamList } from 'lib/typescript/types'
 import React from 'react'
 import {
   FlatList as RNFlatList,
@@ -80,7 +81,7 @@ const init = (children: any) => {
  * <Tabs.ScrollView {...props} />
  * ```
  */
-const createCollapsibleTabs = <T extends string>(tabs: readonly T[]) => {
+const createCollapsibleTabs = <T extends ParamList>(tabs: readonly T[]) => {
   const Context = React.createContext<ContextType<T> | undefined>(undefined)
 
   /**

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -17,7 +17,7 @@ export const useRefMap = (tabIds: readonly ParamList[]) => {
     // this is fine to ignore, our number of tabs shouldn't change
     // eslint-disable-next-line react-hooks/rules-of-hooks
     (refs, tabId) => ({ ...refs, [tabId]: useTabRef() }),
-    {} as Record<string, React.RefObject<RefComponent>>
+    {} as Record<ParamList, React.RefObject<RefComponent>>
   )
 
   const [refMap] = useState(refs)

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { ContainerRef, RefComponent } from 'react-native-collapsible-tab-view'
 import { useAnimatedRef } from 'react-native-reanimated'
 
+import { ParamList } from './types'
+
 export const useContainerRef = () => {
   return useAnimatedRef<ContainerRef>()
 }
@@ -10,7 +12,7 @@ export const useTabRef = () => {
   return useAnimatedRef<RefComponent>()
 }
 
-export const useRefMap = (tabIds: readonly string[]) => {
+export const useRefMap = (tabIds: readonly ParamList[]) => {
   const refs = tabIds.reduce(
     // this is fine to ignore, our number of tabs shouldn't change
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { ContainerRef, RefComponent } from 'react-native-collapsible-tab-view'
+import { useAnimatedRef } from 'react-native-reanimated'
+
+export const useContainerRef = () => {
+  return useAnimatedRef<ContainerRef>()
+}
+
+export const useTabRef = () => {
+  return useAnimatedRef<RefComponent>()
+}
+
+export const useRefMap = (tabIds: readonly string[]) => {
+  const refs = tabIds.reduce(
+    // this is fine to ignore, our number of tabs shouldn't change
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    (refs, tabId) => ({ ...refs, [tabId]: useTabRef() }),
+    {} as Record<string, React.RefObject<RefComponent>>
+  )
+
+  const [refMap] = useState(refs)
+  return refMap
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,3 +27,5 @@ export type {
 export { default as createCollapsibleTabs } from './createCollapsibleTabs'
 
 export { default as MaterialTabBar } from './MaterialTabBar'
+
+export * from './hooks'

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,6 @@ export type OnTabChangeCallback<T extends ParamList> = (data: {
 
 export type CollapsibleProps<T extends ParamList> = {
   initialTabName?: T
-  containerRef: React.RefObject<ContainerRef>
   /**
    * Is optional, but will optimize the first render.
    */
@@ -62,7 +61,6 @@ export type CollapsibleProps<T extends ParamList> = {
   children: React.ReactElement[] | React.ReactElement
   HeaderComponent?: (props: TabBarProps<T>) => React.ReactElement
   TabBarComponent?: (props: TabBarProps<T>) => React.ReactElement
-  refMap: Record<T, Ref>
   headerContainerStyle?: StyleProp<Animated.AnimateStyle<ViewStyle>>
   containerStyle?: StyleProp<ViewStyle>
   cancelTranslation?: boolean


### PR DESCRIPTION
This is an alternative to #90 that simplifies things further.

`containerRef` and `refMap` are no longer needed, the tab names are passed to `createCollapsibleTabs` instead.

I'm not sure if this limits things in any way.

Open for discussion. 

With this PR only `const { useTabsContext, ...Tabs } = createCollapsibleTabs(TabNames)` is needed.