### PR TITLE
fix: switching lazy tabs sometimes jumps scroll position on ios

### DIFF
--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -3,6 +3,7 @@ import { FlatList as RNFlatList, FlatListProps } from 'react-native'
 
 import { AnimatedFlatList, IS_IOS } from './helpers'
 import {
+  useAfterMountEffect,
   useChainCallback,
   useCollapsibleStyle,
   useScrollHandlerY,
@@ -29,7 +30,15 @@ function FlatListImpl<R>(
     scrollYCurrent,
   } = useTabsContext()
   const ref = useSharedAnimatedRef<RNFlatList<unknown>>(passRef)
-  const scrollHandler = useScrollHandlerY(name)
+  const [canBindScrollEvent, setCanBindScrollEvent] = React.useState(false)
+
+  useAfterMountEffect(() => {
+    // we enable the scroll event after mounting
+    // otherwise we get an `onScroll` call with the initial scroll position which can break things
+    setCanBindScrollEvent(true)
+  })
+
+  const scrollHandler = useScrollHandlerY(name, { enabled: canBindScrollEvent })
   const {
     style: _style,
     contentContainerStyle: _contentContainerStyle,

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -4,6 +4,7 @@ import Animated from 'react-native-reanimated'
 
 import { IS_IOS } from './helpers'
 import {
+  useAfterMountEffect,
   useChainCallback,
   useCollapsibleStyle,
   useScrollHandlerY,
@@ -32,11 +33,21 @@ export const ScrollView = React.forwardRef<
       contentInset,
       scrollYCurrent,
     } = useTabsContext()
-    const scrollHandler = useScrollHandlerY(name)
     const {
       style: _style,
       contentContainerStyle: _contentContainerStyle,
     } = useCollapsibleStyle()
+    const [canBindScrollEvent, setCanBindScrollEvent] = React.useState(false)
+
+    useAfterMountEffect(() => {
+      // we enable the scroll event after mounting
+      // otherwise we get an `onScroll` call with the initial scroll position which can break things
+      setCanBindScrollEvent(true)
+    })
+
+    const scrollHandler = useScrollHandlerY(name, {
+      enabled: canBindScrollEvent,
+    })
 
     React.useEffect(() => {
       setRef(name, ref)


### PR DESCRIPTION
This delays handling scroll events until after the scroll controls are mounted.

Otherwise we receive a scroll event for the initial scroll position (via `contentOffset`), and this can create a race condition with the scroll position jumping around.