### PR TITLE
fix: add missing hook dependency

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -446,6 +446,7 @@ export const useScrollHandlerY = (
       snapThreshold,
       clampMax,
       enabled,
+      scrollTo,
     ]
   )
 
@@ -494,7 +495,7 @@ export const useScrollHandlerY = (
         }
       }
     },
-    [revealHeaderOnScroll, refMap, snapThreshold, tabIndex, enabled]
+    [revealHeaderOnScroll, refMap, snapThreshold, tabIndex, enabled, scrollTo]
   )
 
   return scrollHandler


### PR DESCRIPTION
`scrollTo` was not in the dependency array, so updates to the `contentInset` value would not properly propagate to it, resulting in wrong scroll sync positions if the `headerHeight` property was not provided.