### PR TITLE
fix: indicator glitch because scrollX was being reset

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -124,7 +124,8 @@ const Container = React.forwardRef<CollapsibleRef, CollapsibleProps>(
       initialTabName ? tabNames.value.findIndex((n) => n === initialTabName) : 0
     )
     const scrollX: ContextType['scrollX'] = useSharedValue(
-      index.value * windowWidth
+      index.value * windowWidth,
+      false
     )
     const pagerOpacity = useSharedValue(
       initialHeaderHeight === undefined || index.value !== 0 ? 0 : 1,


### PR DESCRIPTION
In reanimated 2 rc.0, `useSharedValue` actually recomputes the value and acts as `useDerivedValue` unless `false` is passed to the second parameter.

This can cause a glitch in the indicator mid-snap if the container needs to re-render.