### PR TITLE
fix: assume headerHeight is 0 if HeaderComponent isn't provided

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -89,7 +89,7 @@ const Container = React.forwardRef<CollapsibleRef, CollapsibleProps>(
       initialTabBarHeight
     )
     const [headerHeight, setHeaderHeight] = React.useState<number | undefined>(
-      initialHeaderHeight
+      !HeaderComponent ? 0 : initialHeaderHeight
     )
 
     const contentInset = React.useMemo(


### PR DESCRIPTION
Fixes #129