### PR TITLE
feat: support custom refresh control component

### DIFF
--- a/example/src/Shared/Albums.tsx
+++ b/example/src/Shared/Albums.tsx
@@ -6,7 +6,7 @@ import {
   View,
   RefreshControl,
 } from 'react-native'
-import { Tabs, useCollapsibleStyle } from 'react-native-collapsible-tab-view'
+import { Tabs } from 'react-native-collapsible-tab-view'
 
 import { useRefresh } from './useRefresh'
 
@@ -33,18 +33,13 @@ export const AlbumsContent = () => {
 
 export const Albums: React.FC = () => {
   const [isRefreshing, startRefreshing] = useRefresh()
-  const { progressViewOffset } = useCollapsibleStyle()
 
   return (
     <Tabs.ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
       refreshControl={
-        <RefreshControl
-          refreshing={isRefreshing}
-          onRefresh={startRefreshing}
-          progressViewOffset={progressViewOffset}
-        />
+        <RefreshControl refreshing={isRefreshing} onRefresh={startRefreshing} />
       }
     >
       <AlbumsContent />

--- a/example/src/Shared/Article.tsx
+++ b/example/src/Shared/Article.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { View, Text, Image, StyleSheet, RefreshControl } from 'react-native'
-import { useCollapsibleStyle, Tabs } from 'react-native-collapsible-tab-view'
+import { Tabs } from 'react-native-collapsible-tab-view'
 
 import { useRefresh } from './useRefresh'
 
@@ -44,18 +44,13 @@ export const ArticleContent = () => {
 
 const Article: React.FC<object> = () => {
   const [isRefreshing, startRefreshing] = useRefresh()
-  const { progressViewOffset } = useCollapsibleStyle()
 
   return (
     <Tabs.ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
       refreshControl={
-        <RefreshControl
-          refreshing={isRefreshing}
-          onRefresh={startRefreshing}
-          progressViewOffset={progressViewOffset}
-        />
+        <RefreshControl refreshing={isRefreshing} onRefresh={startRefreshing} />
       }
     >
       <ArticleContent />

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -18,6 +18,7 @@ function FlatListImpl<R>(
     contentContainerStyle,
     style,
     onContentSizeChange,
+    refreshControl,
     ...rest
   }: Omit<FlatListProps<R>, 'onScroll'>,
   passRef: React.Ref<RNFlatList>
@@ -71,6 +72,13 @@ function FlatListImpl<R>(
         x: 0,
       }}
       automaticallyAdjustContentInsets={false}
+      refreshControl={
+        refreshControl &&
+        React.cloneElement(refreshControl, {
+          progressViewOffset,
+          ...refreshControl.props,
+        })
+      }
     />
   )
 }

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -22,7 +22,14 @@ export const ScrollView = React.forwardRef<
   React.PropsWithChildren<Omit<ScrollViewProps, 'onScroll'>>
 >(
   (
-    { contentContainerStyle, style, onContentSizeChange, children, ...rest },
+    {
+      contentContainerStyle,
+      style,
+      onContentSizeChange,
+      children,
+      refreshControl,
+      ...rest
+    },
     passRef
   ) => {
     const name = useTabNameContext()
@@ -31,6 +38,7 @@ export const ScrollView = React.forwardRef<
     const {
       style: _style,
       contentContainerStyle: _contentContainerStyle,
+      progressViewOffset,
     } = useCollapsibleStyle()
     const [canBindScrollEvent, setCanBindScrollEvent] = React.useState(false)
 
@@ -78,6 +86,13 @@ export const ScrollView = React.forwardRef<
           x: 0,
         }}
         automaticallyAdjustContentInsets={false}
+        refreshControl={
+          refreshControl &&
+          React.cloneElement(refreshControl, {
+            progressViewOffset,
+            ...refreshControl.props,
+          })
+        }
       >
         {children}
       </Animated.ScrollView>


### PR DESCRIPTION
Add `<RefreshControl />` to FlatList and ScrollView. Helps to avoid call the `useCollapsibleStyle` on every refresh control.