### PR TITLE
perf: optimize and reduce rerenders

### DIFF
--- a/example/src/Shared/QuickStartDemo.tsx
+++ b/example/src/Shared/QuickStartDemo.tsx
@@ -4,6 +4,9 @@ import { Tabs } from 'react-native-collapsible-tab-view'
 
 const HEADER_HEIGHT = 250
 
+const DATA = [0, 1, 2, 3, 4]
+const identity = (v: unknown): string => v + ''
+
 const Header = () => {
   return <View style={styles.header} />
 }
@@ -22,9 +25,9 @@ const Example: React.FC = () => {
     >
       <Tabs.Tab name="A">
         <Tabs.FlatList
-          data={[0, 1, 2, 3, 4]}
+          data={DATA}
           renderItem={renderItem}
-          keyExtractor={(v) => v + ''}
+          keyExtractor={identity}
         />
       </Tabs.Tab>
       <Tabs.Tab name="B">

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -65,9 +65,9 @@ function FlatListImpl<R>(
       onScroll={scrollHandler}
       onContentSizeChange={scrollContentSizeChangeHandlers}
       scrollEventThrottle={16}
-      contentInset={{ top: contentInset }}
+      contentInset={{ top: contentInset.value }}
       contentOffset={{
-        y: IS_IOS ? -contentInset + scrollYCurrent.value : 0,
+        y: IS_IOS ? -contentInset.value + scrollYCurrent.value : 0,
         x: 0,
       }}
       automaticallyAdjustContentInsets={false}

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -26,15 +26,14 @@ function FlatListImpl<R>(
   const name = useTabNameContext()
   const { setRef, contentInset, scrollYCurrent } = useTabsContext()
   const ref = useSharedAnimatedRef<RNFlatList<unknown>>(passRef)
-  const [canBindScrollEvent, setCanBindScrollEvent] = React.useState(false)
 
+  const { scrollHandler, enable } = useScrollHandlerY(name)
   useAfterMountEffect(() => {
     // we enable the scroll event after mounting
     // otherwise we get an `onScroll` call with the initial scroll position which can break things
-    setCanBindScrollEvent(true)
+    enable(true)
   })
 
-  const scrollHandler = useScrollHandlerY(name, { enabled: canBindScrollEvent })
   const {
     style: _style,
     contentContainerStyle: _contentContainerStyle,

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -40,16 +40,12 @@ export const ScrollView = React.forwardRef<
       contentContainerStyle: _contentContainerStyle,
       progressViewOffset,
     } = useCollapsibleStyle()
-    const [canBindScrollEvent, setCanBindScrollEvent] = React.useState(false)
 
+    const { scrollHandler, enable } = useScrollHandlerY(name)
     useAfterMountEffect(() => {
       // we enable the scroll event after mounting
       // otherwise we get an `onScroll` call with the initial scroll position which can break things
-      setCanBindScrollEvent(true)
-    })
-
-    const scrollHandler = useScrollHandlerY(name, {
-      enabled: canBindScrollEvent,
+      enable(true)
     })
 
     React.useEffect(() => {

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -15,6 +15,24 @@ import {
 } from './hooks'
 
 /**
+ * Used as a memo to prevent rerendering too often when the context changes.
+ * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
+ */
+const ScrollViewMemo = React.memo(
+  React.forwardRef<RNScrollView, React.PropsWithChildren<ScrollViewProps>>(
+    (props, passRef) => {
+      return (
+        <Animated.ScrollView
+          // @ts-expect-error reanimated types are broken on ref
+          ref={passRef}
+          {...props}
+        />
+      )
+    }
+  )
+)
+
+/**
  * Use like a regular ScrollView.
  */
 export const ScrollView = React.forwardRef<
@@ -40,7 +58,6 @@ export const ScrollView = React.forwardRef<
       contentContainerStyle: _contentContainerStyle,
       progressViewOffset,
     } = useCollapsibleStyle()
-
     const { scrollHandler, enable } = useScrollHandlerY(name)
     useAfterMountEffect(() => {
       // we enable the scroll event after mounting
@@ -57,41 +74,59 @@ export const ScrollView = React.forwardRef<
     })
 
     const scrollContentSizeChangeHandlers = useChainCallback(
-      scrollContentSizeChange,
-      onContentSizeChange
+      React.useMemo(() => [scrollContentSizeChange, onContentSizeChange], [
+        onContentSizeChange,
+        scrollContentSizeChange,
+      ])
     )
 
+    const memoRefreshControl = React.useMemo(
+      () =>
+        refreshControl &&
+        React.cloneElement(refreshControl, {
+          progressViewOffset,
+          ...refreshControl.props,
+        }),
+      [progressViewOffset, refreshControl]
+    )
+    const memoContentOffset = React.useMemo(
+      () => ({
+        y: IS_IOS ? -contentInset.value + scrollYCurrent.value : 0,
+        x: 0,
+      }),
+      [contentInset.value, scrollYCurrent.value]
+    )
+    const memoContentInset = React.useMemo(
+      () => ({ top: contentInset.value }),
+      [contentInset.value]
+    )
+    const memoContentContainerStyle = React.useMemo(
+      () => [
+        _contentContainerStyle,
+        // TODO: investigate types
+        contentContainerStyle as any,
+      ],
+      [_contentContainerStyle, contentContainerStyle]
+    )
+    const memoStyle = React.useMemo(() => [_style, style], [_style, style])
+
     return (
-      <Animated.ScrollView
+      <ScrollViewMemo
         {...rest}
-        // @ts-expect-error reanimated types are broken on ref
         ref={ref}
         bouncesZoom={false}
-        style={[_style, style]}
-        contentContainerStyle={[
-          _contentContainerStyle,
-          // TODO: investigate types
-          contentContainerStyle as any,
-        ]}
+        style={memoStyle}
+        contentContainerStyle={memoContentContainerStyle}
         onScroll={scrollHandler}
         onContentSizeChange={scrollContentSizeChangeHandlers}
         scrollEventThrottle={16}
-        contentInset={{ top: contentInset.value }}
-        contentOffset={{
-          y: IS_IOS ? -contentInset.value + scrollYCurrent.value : 0,
-          x: 0,
-        }}
+        contentInset={memoContentInset}
+        contentOffset={memoContentOffset}
         automaticallyAdjustContentInsets={false}
-        refreshControl={
-          refreshControl &&
-          React.cloneElement(refreshControl, {
-            progressViewOffset,
-            ...refreshControl.props,
-          })
-        }
+        refreshControl={memoRefreshControl}
       >
         {children}
-      </Animated.ScrollView>
+      </ScrollViewMemo>
     )
   }
 )

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -76,9 +76,9 @@ export const ScrollView = React.forwardRef<
         onScroll={scrollHandler}
         onContentSizeChange={scrollContentSizeChangeHandlers}
         scrollEventThrottle={16}
-        contentInset={{ top: contentInset }}
+        contentInset={{ top: contentInset.value }}
         contentOffset={{
-          y: IS_IOS ? -contentInset + scrollYCurrent.value : 0,
+          y: IS_IOS ? -contentInset.value + scrollYCurrent.value : 0,
           x: 0,
         }}
         automaticallyAdjustContentInsets={false}

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -151,14 +151,13 @@ export function useCollapsibleStyle(): CollapsibleStyle {
 
 export function useUpdateScrollViewContentSize({ name }: { name: TabName }) {
   const { tabNames, contentHeights } = useTabsContext()
-
   const setContentHeights = useCallback(
     (name: TabName, height: number) => {
       const tabIndex = tabNames.value.indexOf(name)
       contentHeights.value[tabIndex] = height
       contentHeights.value = [...contentHeights.value]
     },
-    [contentHeights, tabNames.value]
+    [contentHeights, tabNames]
   )
 
   const scrollContentSizeChange = useCallback(
@@ -177,7 +176,7 @@ export function useUpdateScrollViewContentSize({ name }: { name: TabName }) {
  * @param fns array of functions to call
  * @returns a function that once called will call all passed functions
  */
-export function useChainCallback(...fns: (Function | undefined)[]) {
+export function useChainCallback(fns: (Function | undefined)[]) {
   const callAll = useCallback(
     (...args: unknown[]) => {
       fns.forEach((fn) => {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -204,10 +204,7 @@ export function useScroller<T extends RefComponent>() {
   return scroller
 }
 
-export const useScrollHandlerY = (
-  name: TabName,
-  { enabled }: { enabled: boolean }
-) => {
+export const useScrollHandlerY = (name: TabName) => {
   const {
     accDiffClamp,
     focusedTab,
@@ -231,6 +228,15 @@ export const useScrollHandlerY = (
     snappingTo,
     contentHeights,
   } = useTabsContext()
+
+  const enabled = useSharedValue(false)
+
+  const enable = useCallback(
+    (toggle: boolean) => {
+      enabled.value = toggle
+    },
+    [enabled]
+  )
 
   /**
    * Helper value to track if user is dragging on iOS, because iOS calls
@@ -478,7 +484,7 @@ export const useScrollHandlerY = (
     [revealHeaderOnScroll, refMap, snapThreshold, tabIndex, enabled, scrollTo]
   )
 
-  return scrollHandler
+  return { scrollHandler, enable }
 }
 
 type ForwardRefType<T> =
@@ -514,7 +520,7 @@ export function useSharedAnimatedRef<T extends RefComponent>(
 
 export function useAfterMountEffect(effect: React.EffectCallback) {
   const [didExecute, setDidExecute] = useState(false)
-  const result = useEffect(() => {
+  useEffect(() => {
     if (didExecute) return
 
     const timeout = setTimeout(() => {
@@ -525,7 +531,6 @@ export function useAfterMountEffect(effect: React.EffectCallback) {
       clearTimeout(timeout)
     }
   }, [didExecute, effect])
-  return result
 }
 
 export function useConvertAnimatedToValue<T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,8 +139,8 @@ export type CollapsibleProps = {
 }
 
 export type ContextType<T extends TabName = TabName> = {
-  headerHeight: number
-  tabBarHeight: number
+  headerHeight: Animated.SharedValue<number | undefined>
+  tabBarHeight: Animated.SharedValue<number | undefined>
   revealHeaderOnScroll: boolean
   snapThreshold: number | null | undefined
   /**
@@ -173,7 +173,7 @@ export type ContextType<T extends TabName = TabName> = {
    * Array of the scroll y position of each tab.
    */
   scrollY: Animated.SharedValue<number[]>
-  containerHeight?: number
+  containerHeight: Animated.SharedValue<number | undefined>
   /**
    * Object containing the ref of each scrollable component.
    */
@@ -219,7 +219,7 @@ export type ContextType<T extends TabName = TabName> = {
    */
   contentHeights: Animated.SharedValue<number[]>
 
-  contentInset: number
+  contentInset: Animated.SharedValue<number>
 
   headerTranslateY: Animated.SharedValue<number>
 }


### PR DESCRIPTION
This should greatly improve performance, especially with scrollable tab bars.

It also optimizes various other things, and reduces rerenders a bit.

It should be possible to test it by adding a `git` dependency directly:

```
    "react-native-collapsible-tab-view": "PedroBern/react-native-collapsible-tab-view#perf-rerenders",
```