### PR TITLE
docs: fix typo in to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ const tabIndex = useAnimatedTabIndex()
 Returns the currently focused tab name.
 
 ```tsx
-const focusedTab = useAnimatedTabIndex()
+const focusedTab = useFocusedTab()
 ```
 
 ### useHeaderMeasurements

--- a/documentation/README_TEMPLATE.md
+++ b/documentation/README_TEMPLATE.md
@@ -155,7 +155,7 @@ const tabIndex = useAnimatedTabIndex()
 Returns the currently focused tab name.
 
 ```tsx
-const focusedTab = useAnimatedTabIndex()
+const focusedTab = useFocusedTab()
 ```
 
 ### useHeaderMeasurements


### PR DESCRIPTION
Change `useAnimatedTabIndex()` under useFocusedTab sub heading to the right method.