### PR TITLE
feat: add `width` prop to `Tabs.Container`

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,6 @@ Any additional props are passed to the pressable component.
 |scrollEnabled|`boolean \| undefined`|||
 |style|`StyleProp<ViewStyle>`||Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.|
 
-|width|`number \| undefined`||Optionally set a custom width of the tab bar. Defaults to the window width.|
-
-
 # Known issues
 
 ## Android FlatList pull to refresh

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ const Example = () => {
 |revealHeaderOnScroll|`boolean \| undefined`||Reveal header when scrolling down. Implements diffClamp.|
 |snapThreshold|`number \| null \| undefined`|`null`|Percentage of header height to define as the snap point. A number between 0 and 1, or `null` to disable snapping.|
 |tabBarHeight|`number \| undefined`||Is optional, but will optimize the first render.|
+|width|`number \| undefined`||Optionally set a custom width of the container. Defaults to the window width.|
 
 ### Tabs.Tab
 
@@ -342,6 +343,7 @@ Any additional props are passed to the pressable component.
 |scrollEnabled|`boolean \| undefined`|||
 |style|`StyleProp<ViewStyle>`||Either view styles or a function that receives a boolean reflecting whether the component is currently pressed and returns view styles.|
 
+|width|`number \| undefined`||Optionally set a custom width of the tab bar. Defaults to the window width.|
 
 
 # Known issues

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -81,6 +81,7 @@ export const Container = React.memo(
         pagerProps,
         onIndexChange,
         onTabChange,
+        width: customWidth,
       },
       ref
     ) => {
@@ -91,6 +92,7 @@ export const Container = React.memo(
       const [refMap, setRef] = useAnimatedDynamicRefs()
 
       const windowWidth = useWindowDimensions().width
+      const width = customWidth ?? windowWidth
       const firstRender = React.useRef(true)
 
       const containerHeight = useSharedValue<number | undefined>(undefined)
@@ -137,7 +139,7 @@ export const Container = React.memo(
           : 0
       )
       const scrollX: ContextType['scrollX'] = useSharedValue(
-        index.value * windowWidth
+        index.value * width
       )
       const pagerOpacity = useSharedValue(
         initialHeaderHeight === undefined || index.value !== 0 ? 0 : 1
@@ -160,16 +162,16 @@ export const Container = React.memo(
 
       const getItemLayout = React.useCallback(
         (_: unknown, index: number) => ({
-          length: windowWidth,
-          offset: windowWidth * index,
+          length: width,
+          offset: width * index,
           index,
         }),
-        [windowWidth]
+        [width]
       )
 
       const indexDecimal: ContextType['indexDecimal'] = useDerivedValue(() => {
-        return scrollX.value / windowWidth
-      }, [windowWidth])
+        return scrollX.value / width
+      }, [width])
 
       // handle window resize
       React.useEffect(() => {
@@ -180,7 +182,7 @@ export const Container = React.memo(
           })
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [windowWidth])
+      }, [width])
 
       const afterRender = useSharedValue(0)
       React.useEffect(() => {
@@ -202,7 +204,7 @@ export const Container = React.memo(
           firstRender.current = false
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [containerRef, initialTabName, windowWidth])
+      }, [containerRef, initialTabName, width])
 
       // the purpose of this is to scroll to the proper position if dynamic tabs are changing
       useAnimatedReaction(
@@ -466,10 +468,11 @@ export const Container = React.memo(
             snappingTo,
             contentHeights,
             headerTranslateY,
+            width,
           }}
         >
           <Animated.View
-            style={[styles.container, containerStyle]}
+            style={[styles.container, { width }, containerStyle]}
             onLayout={onLayout}
             pointerEvents="box-none"
           >
@@ -509,6 +512,7 @@ export const Container = React.memo(
                     tabNames: tabNamesArray,
                     focusedTab,
                     indexDecimal,
+                    width,
                     onTabPress,
                     tabProps,
                   })}

--- a/src/MaterialTabBar/TabBar.tsx
+++ b/src/MaterialTabBar/TabBar.tsx
@@ -57,9 +57,11 @@ const MaterialTabBar = <T extends TabName = any>({
   inactiveColor,
   activeColor,
   tabStyle,
+  width: customWidth,
 }: MaterialTabBarProps<T>): React.ReactElement => {
   const tabBarRef = useAnimatedRef<Animated.ScrollView>()
   const windowWidth = useWindowDimensions().width
+  const width = customWidth ?? windowWidth
   const isFirstRender = React.useRef(true)
   const itemLayoutGathering = React.useRef(new Map<T, ItemLayout>())
 
@@ -72,7 +74,7 @@ const MaterialTabBar = <T extends TabName = any>({
     scrollEnabled
       ? []
       : tabNames.map((_, i) => {
-          const tabWidth = windowWidth / nTabs
+          const tabWidth = width / nTabs
           return { width: tabWidth, x: i * tabWidth }
         })
   )
@@ -82,14 +84,14 @@ const MaterialTabBar = <T extends TabName = any>({
       isFirstRender.current = false
     } else if (!scrollEnabled) {
       // update items width on window resizing
-      const tabWidth = windowWidth / nTabs
+      const tabWidth = width / nTabs
       setItemsLayout(
         tabNames.map((_, i) => {
           return { width: tabWidth, x: i * tabWidth }
         })
       )
     }
-  }, [scrollEnabled, nTabs, tabNames, windowWidth])
+  }, [scrollEnabled, nTabs, tabNames, width])
 
   const onTabItemLayout = React.useCallback(
     (event: LayoutChangeEvent, name: T) => {
@@ -166,9 +168,9 @@ const MaterialTabBar = <T extends TabName = any>({
         const offset = itemsLayout[index.value].x
         if (
           offset < tabsOffset.value ||
-          offset > tabsOffset.value + windowWidth - 2 * halfTab
+          offset > tabsOffset.value + width - 2 * halfTab
         ) {
-          scrollTo(tabBarRef, offset - windowWidth / 2 + halfTab, 0, true)
+          scrollTo(tabBarRef, offset - width / 2 + halfTab, 0, true)
         }
       }
     },
@@ -181,7 +183,7 @@ const MaterialTabBar = <T extends TabName = any>({
       style={style}
       contentContainerStyle={[
         styles.contentContainer,
-        !scrollEnabled && { width: windowWidth },
+        !scrollEnabled && { width },
         contentContainerStyle,
       ]}
       keyboardShouldPersistTaps="handled"

--- a/src/MaterialTabBar/types.ts
+++ b/src/MaterialTabBar/types.ts
@@ -79,6 +79,11 @@ export type MaterialTabBarProps<N extends TabName> = TabBarProps<N> & {
    * Color applied to the label when inactive
    */
   inactiveColor?: string
+
+  /**
+   * Custom width of the tabbar. Defaults to the window width.
+   */
+  width?: number
 }
 
 export type ItemLayout = {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -7,7 +7,6 @@ import {
   MutableRefObject,
   useEffect,
 } from 'react'
-import { useWindowDimensions } from 'react-native'
 import { ContainerRef, RefComponent } from 'react-native-collapsible-tab-view'
 import Animated, {
   cancelAnimation,
@@ -125,8 +124,12 @@ export function useTabNameContext(): TabName {
  * You can use this to get the progessViewOffset and pass to the refresh control of scroll view.
  */
 export function useCollapsibleStyle(): CollapsibleStyle {
-  const { headerHeight, tabBarHeight, containerHeight } = useTabsContext()
-  const windowWidth = useWindowDimensions().width
+  const {
+    headerHeight,
+    tabBarHeight,
+    containerHeight,
+    width,
+  } = useTabsContext()
   const [containerHeightVal, tabBarHeightVal, headerHeightVal] = [
     useConvertAnimatedToValue(containerHeight),
     useConvertAnimatedToValue(tabBarHeight),
@@ -134,7 +137,7 @@ export function useCollapsibleStyle(): CollapsibleStyle {
   ]
   return useMemo(
     () => ({
-      style: { width: windowWidth },
+      style: { width },
       contentContainerStyle: {
         minHeight: IS_IOS
           ? (containerHeightVal || 0) - (tabBarHeightVal || 0)
@@ -145,7 +148,7 @@ export function useCollapsibleStyle(): CollapsibleStyle {
       },
       progressViewOffset: (headerHeightVal || 0) + (tabBarHeightVal || 0),
     }),
-    [containerHeightVal, headerHeightVal, tabBarHeightVal, windowWidth]
+    [containerHeightVal, headerHeightVal, tabBarHeightVal, width]
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,11 @@ export type CollapsibleProps = {
    *  index and tabnames.
    */
   onTabChange?: OnTabChangeCallback<TabName>
+
+  /**
+   * Custom width of the container. Defaults to the window width.
+   */
+  width?: number
 }
 
 export type ContextType<T extends TabName = TabName> = {
@@ -227,6 +232,8 @@ export type ContextType<T extends TabName = TabName> = {
   contentInset: Animated.SharedValue<number>
 
   headerTranslateY: Animated.SharedValue<number>
+
+  width: number
 }
 
 export type ScrollViewProps = ComponentProps<typeof Animated.ScrollView>


### PR DESCRIPTION
First of all, thank you for a really great library! It deals with some really hard to pull off user interactions!

In an app we're building we get an issue where the window width is miscalulated after having rotated from portrait to landscape and then back to portrait. React native's built in `useWindowDimensions` hook will still return the landscape width even if the app is rotated back to portrait mode. 

Our specific case is probably quite extraordinary, we actually switch between a portrait UIWindow to a landscape UIWindow and then back. And when we do we still get landscape width which causes parts of the tab view to render outside of the screen. When swiping between tabs the app will crash.

Replacing the `useWindowDimensions` hook with `useSafeAreaFrame` from `react-native-safe-area-context` solvess this problem entirely.

We previously used `useWindowDimensions` in other places in our app but replaced them with `useSafeAreaFrame` and it fixed several  issues we've had with wrong or not updating values. Looking through react native github issues it seems other people have similar problems with this hook: [#29290](https://github.com/facebook/react-native/issues/29290) [#31692](https://github.com/facebook/react-native/issues/31692) [#30371](https://github.com/facebook/react-native/issues/30371) [#32279](https://github.com/facebook/react-native/issues/32279)

I understand that this change introduces a new peer dependency on the project but I really think it's worth it in this case!