### PR TITLE
Update TabReactElement - allow null as Tab

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export type OnTabChangeCallback<T extends TabName = TabName> = (
 ) => void
 
 export type TabReactElement<T extends TabName = TabName> = React.ReactElement<
-  TabProps<T>
+  TabProps<T> | null
 >
 
 export type CollapsibleProps = {


### PR DESCRIPTION
Without this, TypeScript linter won't allow conditional tabs with a `null` return.