### PR TITLE
Feat/header touchables and horizontal scroll

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,6 +26,7 @@ import Ref from './Ref'
 import RevealHeaderOnScroll from './RevealHeaderOnScroll'
 import RevealHeaderOnScrollSnap from './RevealHeaderOnScrollSnap'
 import ScrollOnHeader from './ScrollOnHeader'
+import ScrollOnHeaderWithTouchables from './ScrollOnHeaderWithTouchables'
 import ScrollableTabs from './ScrollableTabs'
 import Snap from './Snap'
 import StartOnSpecificTab from './StartOnSpecificTab'
@@ -51,6 +52,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   AnimatedHeader,
   AndroidSharedPullToRefresh,
   HeaderOverscrollExample,
+  ScrollOnHeaderWithTouchables,
 ]
 
 const ExampleList: React.FC<object> = () => {

--- a/example/src/ScrollOnHeaderWithTouchables.tsx
+++ b/example/src/ScrollOnHeaderWithTouchables.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react'
+import {
+  StyleSheet,
+  View,
+  FlatList,
+  Text,
+  Alert,
+  TouchableOpacity,
+} from 'react-native'
+
+import { TabBarProps } from '../../src/types'
+import ExampleComponent from './Shared/ExampleComponent'
+import { ExampleComponentType } from './types'
+
+const title = 'Scroll On Header with Touchables'
+
+const SLIDER_ITEM_SIZE = 200
+const HEADER_HEIGHT = SLIDER_ITEM_SIZE * 2
+
+const data = Array.from({ length: 15 }).map((_, i) => i.toString())
+
+const styles = StyleSheet.create({
+  item: {
+    width: SLIDER_ITEM_SIZE,
+    height: SLIDER_ITEM_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  itemButton: {
+    padding: 16,
+    backgroundColor: 'white',
+  },
+  itemName: {
+    fontSize: 48,
+    color: 'black',
+  },
+  itemSeparator: { width: 4 },
+})
+
+const Slider = ({ isReversed = false }) => {
+  const config = useMemo(
+    () => ({
+      data: isReversed ? [...data].reverse() : data,
+      backgroundColor: isReversed ? 'purple' : 'orangered',
+    }),
+    [isReversed]
+  )
+
+  return (
+    <FlatList
+      data={config.data}
+      horizontal
+      keyExtractor={(item) => item}
+      showsHorizontalScrollIndicator={false}
+      ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
+      bounces={false}
+      renderItem={({ item }) => (
+        <View
+          style={[styles.item, { backgroundColor: config.backgroundColor }]}
+        >
+          <TouchableOpacity
+            style={styles.itemButton}
+            onPress={() => Alert.alert(`Touchable number ${item} pressed`)}
+          >
+            <Text style={styles.itemName}>{item}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    />
+  )
+}
+
+const NewHeader: React.FC<TabBarProps> = () => {
+  return (
+    <View>
+      <Slider />
+      <Slider isReversed />
+    </View>
+  )
+}
+
+const DefaultExample: ExampleComponentType = () => {
+  return (
+    <ExampleComponent renderHeader={NewHeader} headerHeight={HEADER_HEIGHT} />
+  )
+}
+
+DefaultExample.title = title
+
+export default DefaultExample
+diff --git a/example/src/App.tsx b/example/src/App.tsx

--- a/example/src/ScrollOnHeaderWithTouchables.tsx
+++ b/example/src/ScrollOnHeaderWithTouchables.tsx
@@ -88,4 +88,3 @@ const DefaultExample: ExampleComponentType = () => {
 DefaultExample.title = title
 
 export default DefaultExample
-diff --git a/example/src/App.tsx b/example/src/App.tsx

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -460,7 +460,10 @@ export const Container = React.memo(
             onLayout={onLayout}
             pointerEvents="box-none"
           >
-            <TopContainer>
+            <TopContainer
+              cancelTranslation={cancelTranslation}
+              headerContainerStyle={headerContainerStyle}
+            >
               <HeaderContainer
                 containerRef={containerRef}
                 onTabPress={onTabPress}

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -3,32 +3,25 @@ import {
   LayoutChangeEvent,
   StyleSheet,
   useWindowDimensions,
-  View,
 } from 'react-native'
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler'
 import Animated, {
-  Extrapolate,
-  interpolate,
   runOnJS,
   runOnUI,
-  useAnimatedGestureHandler,
   useAnimatedReaction,
   useAnimatedScrollHandler,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
-  withDecay,
   withDelay,
   withTiming,
 } from 'react-native-reanimated'
 
 import { Context, TabNameContext } from './Context'
+import { HeaderContainer } from './HeaderContainer'
 import { Lazy } from './Lazy'
 import { MaterialTabBar, TABBAR_HEIGHT } from './MaterialTabBar'
 import { Tab } from './Tab'
+import { TabBarContainer } from './TabBarContainer'
 import {
   AnimatedFlatList,
   IS_IOS,
@@ -133,6 +126,7 @@ export const Container = React.memo(
       const oldAccScrollY: ContextType['oldAccScrollY'] = useSharedValue(0)
       const accDiffClamp: ContextType['accDiffClamp'] = useSharedValue(0)
       const isScrolling: ContextType['isScrolling'] = useSharedValue(0)
+      const isSlidingHeader = useSharedValue(false)
       const scrollYCurrent: ContextType['scrollYCurrent'] = useSharedValue(0)
       const scrollY: ContextType['scrollY'] = useSharedValue(
         tabNamesArray.map(() => 0)
@@ -327,43 +321,6 @@ export const Container = React.memo(
         [children, lazy, tabNames.value, cancelLazyFadeIn]
       )
 
-      const isSlidingHeader = useSharedValue(false)
-
-      const gestureHandler = useAnimatedGestureHandler<
-        PanGestureHandlerGestureEvent,
-        { startY: number }
-      >({
-        onActive: (event, ctx) => {
-          if (!isSlidingHeader.value) {
-            ctx.startY = scrollYCurrent.value
-            isSlidingHeader.value = true
-
-            return
-          }
-
-          scrollYCurrent.value = interpolate(
-            -event.translationY + ctx.startY,
-            [0, headerHeight.value!],
-            [0, headerHeight.value!],
-            Extrapolate.CLAMP
-          )
-        },
-        onEnd: (evt, ctx) => {
-          if (!isSlidingHeader.value) return
-
-          ctx.startY = 0
-          scrollYCurrent.value = withDecay(
-            {
-              velocity: -evt.velocityY,
-              clamp: [0, headerHeight.value!],
-            },
-            () => {
-              isSlidingHeader.value = false
-            }
-          )
-        },
-      })
-
       useAnimatedReaction(
         () => scrollYCurrent.value - contentInset.value,
         (nextPosition, previousPosition) => {
@@ -393,24 +350,6 @@ export const Container = React.memo(
           ],
         }
       }, [revealHeaderOnScroll])
-
-      const getHeaderHeight = React.useCallback(
-        (event: LayoutChangeEvent) => {
-          const height = event.nativeEvent.layout.height
-          if (headerHeight.value !== height) {
-            headerHeight.value = height
-          }
-        },
-        [headerHeight]
-      )
-
-      const getTabBarHeight = React.useCallback(
-        (event: LayoutChangeEvent) => {
-          const height = event.nativeEvent.layout.height
-          if (tabBarHeight.value !== height) tabBarHeight.value = height
-        },
-        [tabBarHeight]
-      )
 
       const onLayout = React.useCallback(
         (event: LayoutChangeEvent) => {
@@ -540,50 +479,32 @@ export const Container = React.memo(
             onLayout={onLayout}
             pointerEvents="box-none"
           >
-            <PanGestureHandler onGestureEvent={gestureHandler}>
-              <Animated.View
-                pointerEvents="box-none"
-                style={[
-                  styles.topContainer,
-                  headerContainerStyle,
-                  !cancelTranslation && stylez,
-                ]}
-              >
-                <View
-                  style={[styles.container, styles.headerContainer]}
-                  onLayout={getHeaderHeight}
-                  pointerEvents="box-none"
-                >
-                  {renderHeader &&
-                    renderHeader({
-                      containerRef,
-                      index,
-                      tabNames: tabNamesArray,
-                      focusedTab,
-                      indexDecimal,
-                      onTabPress,
-                      tabProps,
-                    })}
-                </View>
-                <View
-                  style={[styles.container, styles.tabBarContainer]}
-                  onLayout={getTabBarHeight}
-                  pointerEvents="box-none"
-                >
-                  {renderTabBar &&
-                    renderTabBar({
-                      containerRef,
-                      index,
-                      tabNames: tabNamesArray,
-                      focusedTab,
-                      indexDecimal,
-                      width,
-                      onTabPress,
-                      tabProps,
-                    })}
-                </View>
-              </Animated.View>
-            </PanGestureHandler>
+            <Animated.View
+              pointerEvents="box-none"
+              style={[
+                styles.topContainer,
+                headerContainerStyle,
+                !cancelTranslation && stylez,
+              ]}
+            >
+              <HeaderContainer
+                containerRef={containerRef}
+                onTabPress={onTabPress}
+                tabNamesArray={tabNamesArray}
+                tabProps={tabProps}
+                renderHeader={renderHeader}
+              />
+
+              <TabBarContainer
+                containerRef={containerRef}
+                onTabPress={onTabPress}
+                tabNamesArray={tabNamesArray}
+                tabProps={tabProps}
+                width={width}
+                renderTabBar={renderTabBar}
+              />
+            </Animated.View>
+
             {headerHeight !== undefined && (
               <AnimatedFlatList
                 ref={containerRef}
@@ -626,11 +547,5 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.23,
     shadowRadius: 2.62,
     elevation: 4,
-  },
-  tabBarContainer: {
-    zIndex: 1,
-  },
-  headerContainer: {
-    zIndex: 2,
   },
 })

--- a/src/HeaderContainer.tsx
+++ b/src/HeaderContainer.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { LayoutChangeEvent, StyleSheet } from 'react-native'
+import {
+  PanGestureHandler,
+  PanGestureHandlerGestureEvent,
+} from 'react-native-gesture-handler'
+import Animated, {
+  Extrapolate,
+  interpolate,
+  useAnimatedGestureHandler,
+  withDecay,
+} from 'react-native-reanimated'
+
+import { useTabsContext } from './hooks'
+import { CollapsibleProps, TabBarProps, TabName } from './types'
+
+type HeaderContainerProps<T extends TabName = TabName> = Pick<
+  CollapsibleProps,
+  'renderHeader'
+> &
+  Pick<TabBarProps<T>, 'containerRef' | 'onTabPress' | 'tabProps'> & {
+    tabNamesArray: TabName[]
+  }
+
+export const HeaderContainer: React.FC<HeaderContainerProps> = ({
+  renderHeader,
+  containerRef,
+  tabNamesArray,
+  onTabPress,
+  tabProps,
+}) => {
+  const {
+    isSlidingHeader,
+    scrollYCurrent,
+    headerHeight,
+    focusedTab,
+    index,
+    indexDecimal,
+  } = useTabsContext()
+
+  const getHeaderHeight = React.useCallback(
+    (event: LayoutChangeEvent) => {
+      const height = event.nativeEvent.layout.height
+      if (headerHeight.value !== height) {
+        headerHeight.value = height
+      }
+    },
+    [headerHeight]
+  )
+
+  const gestureHandler = useAnimatedGestureHandler<
+    PanGestureHandlerGestureEvent,
+    { startY: number }
+  >({
+    onActive: (event, ctx) => {
+      if (!isSlidingHeader.value) {
+        ctx.startY = scrollYCurrent.value
+        isSlidingHeader.value = true
+
+        return
+      }
+
+      scrollYCurrent.value = interpolate(
+        -event.translationY + ctx.startY,
+        [0, headerHeight.value!],
+        [0, headerHeight.value!],
+        Extrapolate.CLAMP
+      )
+    },
+    onEnd: (evt, ctx) => {
+      if (!isSlidingHeader.value) return
+
+      ctx.startY = 0
+      scrollYCurrent.value = withDecay(
+        {
+          velocity: -evt.velocityY,
+          clamp: [0, headerHeight.value!],
+        },
+        () => {
+          isSlidingHeader.value = false
+        }
+      )
+    },
+  })
+
+  return (
+    <PanGestureHandler onGestureEvent={gestureHandler}>
+      <Animated.View
+        style={[styles.container]}
+        onLayout={getHeaderHeight}
+        pointerEvents="box-none"
+      >
+        {renderHeader &&
+          renderHeader({
+            containerRef,
+            index,
+            tabNames: tabNamesArray,
+            focusedTab,
+            indexDecimal,
+            onTabPress,
+            tabProps,
+          })}
+      </Animated.View>
+    </PanGestureHandler>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    zIndex: 2,
+    flex: 1,
+  },
+})

--- a/src/HeaderContainer.tsx
+++ b/src/HeaderContainer.tsx
@@ -1,15 +1,5 @@
 import React from 'react'
-import { LayoutChangeEvent, StyleSheet } from 'react-native'
-import {
-  PanGestureHandler,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler'
-import Animated, {
-  Extrapolate,
-  interpolate,
-  useAnimatedGestureHandler,
-  withDecay,
-} from 'react-native-reanimated'
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native'
 
 import { useTabsContext } from './hooks'
 import { CollapsibleProps, TabBarProps, TabName } from './types'
@@ -29,14 +19,7 @@ export const HeaderContainer: React.FC<HeaderContainerProps> = ({
   onTabPress,
   tabProps,
 }) => {
-  const {
-    isSlidingHeader,
-    scrollYCurrent,
-    headerHeight,
-    focusedTab,
-    index,
-    indexDecimal,
-  } = useTabsContext()
+  const { headerHeight, focusedTab, index, indexDecimal } = useTabsContext()
 
   const getHeaderHeight = React.useCallback(
     (event: LayoutChangeEvent) => {
@@ -48,60 +31,19 @@ export const HeaderContainer: React.FC<HeaderContainerProps> = ({
     [headerHeight]
   )
 
-  const gestureHandler = useAnimatedGestureHandler<
-    PanGestureHandlerGestureEvent,
-    { startY: number }
-  >({
-    onActive: (event, ctx) => {
-      if (!isSlidingHeader.value) {
-        ctx.startY = scrollYCurrent.value
-        isSlidingHeader.value = true
-
-        return
-      }
-
-      scrollYCurrent.value = interpolate(
-        -event.translationY + ctx.startY,
-        [0, headerHeight.value!],
-        [0, headerHeight.value!],
-        Extrapolate.CLAMP
-      )
-    },
-    onEnd: (evt, ctx) => {
-      if (!isSlidingHeader.value) return
-
-      ctx.startY = 0
-      scrollYCurrent.value = withDecay(
-        {
-          velocity: -evt.velocityY,
-          clamp: [0, headerHeight.value!],
-        },
-        () => {
-          isSlidingHeader.value = false
-        }
-      )
-    },
-  })
-
   return (
-    <PanGestureHandler onGestureEvent={gestureHandler}>
-      <Animated.View
-        style={[styles.container]}
-        onLayout={getHeaderHeight}
-        pointerEvents="box-none"
-      >
-        {renderHeader &&
-          renderHeader({
-            containerRef,
-            index,
-            tabNames: tabNamesArray,
-            focusedTab,
-            indexDecimal,
-            onTabPress,
-            tabProps,
-          })}
-      </Animated.View>
-    </PanGestureHandler>
+    <View style={[styles.container]} onLayout={getHeaderHeight}>
+      {renderHeader &&
+        renderHeader({
+          containerRef,
+          index,
+          tabNames: tabNamesArray,
+          focusedTab,
+          indexDecimal,
+          onTabPress,
+          tabProps,
+        })}
+    </View>
   )
 }
 

--- a/src/TabBarContainer.tsx
+++ b/src/TabBarContainer.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native'
+
+import { useTabsContext } from './hooks'
+import { CollapsibleProps, TabBarProps, TabName } from './types'
+
+type TabBarContainerProps<T extends TabName = TabName> = Pick<
+  CollapsibleProps,
+  'renderTabBar' | 'width'
+> &
+  Pick<TabBarProps<T>, 'onTabPress' | 'tabProps' | 'containerRef'> & {
+    tabNamesArray: TabName[]
+  }
+
+export const TabBarContainer: React.FC<TabBarContainerProps> = ({
+  renderTabBar,
+  onTabPress,
+  tabProps,
+  tabNamesArray,
+  containerRef,
+  width,
+}) => {
+  const { tabBarHeight, focusedTab, index, indexDecimal } = useTabsContext()
+
+  const getTabBarHeight = React.useCallback(
+    (event: LayoutChangeEvent) => {
+      const height = event.nativeEvent.layout.height
+      if (tabBarHeight.value !== height) tabBarHeight.value = height
+    },
+    [tabBarHeight]
+  )
+
+  return (
+    <View style={[styles.container]} onLayout={getTabBarHeight}>
+      {renderTabBar &&
+        renderTabBar({
+          containerRef,
+          index,
+          tabNames: tabNamesArray,
+          focusedTab,
+          indexDecimal,
+          width,
+          onTabPress,
+          tabProps,
+        })}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, zIndex: 1 },
+})

--- a/src/TopContainer.tsx
+++ b/src/TopContainer.tsx
@@ -11,10 +11,11 @@ import Animated, {
   useAnimatedGestureHandler,
   withDecay,
   useAnimatedReaction,
+  useSharedValue,
 } from 'react-native-reanimated'
 
-import { scrollToImpl } from './helpers'
-import { useTabsContext } from './hooks'
+import { IS_IOS, scrollToImpl } from './helpers'
+import { useOnScroll, useSnap, useTabsContext } from './hooks'
 import { CollapsibleProps } from './types'
 
 type TabBarContainerProps = Pick<
@@ -32,12 +33,18 @@ export const TopContainer: React.FC<TabBarContainerProps> = ({
     revealHeaderOnScroll,
     isSlidingTopContainer,
     scrollYCurrent,
-    headerHeight,
     contentInset,
     refMap,
     tabNames,
     index,
+    headerScrollDistance,
   } = useTabsContext()
+
+  const isSlidingTopContainerPrev = useSharedValue(false)
+  const isTopContainerOutOfSync = useSharedValue(false)
+
+  const tryToSnap = useSnap()
+  const onScroll = useOnScroll()
 
   const animatedStyles = useAnimatedStyle(() => {
     return {
@@ -49,6 +56,12 @@ export const TopContainer: React.FC<TabBarContainerProps> = ({
     }
   }, [revealHeaderOnScroll])
 
+  const syncActiveTabScroll = (position: number) => {
+    'worklet'
+
+    scrollToImpl(refMap[tabNames.value[index.value]], 0, position, false)
+  }
+
   const gestureHandler = useAnimatedGestureHandler<
     PanGestureHandlerGestureEvent,
     { startY: number }
@@ -57,44 +70,66 @@ export const TopContainer: React.FC<TabBarContainerProps> = ({
       if (!isSlidingTopContainer.value) {
         ctx.startY = scrollYCurrent.value
         isSlidingTopContainer.value = true
-
         return
       }
 
       scrollYCurrent.value = interpolate(
         -event.translationY + ctx.startY,
-        [0, headerHeight.value!],
-        [0, headerHeight.value!],
+        [0, headerScrollDistance.value],
+        [0, headerScrollDistance.value],
         Extrapolate.CLAMP
       )
     },
-    onEnd: (evt, ctx) => {
+    onEnd: (event, ctx) => {
       if (!isSlidingTopContainer.value) return
 
       ctx.startY = 0
       scrollYCurrent.value = withDecay(
         {
-          velocity: -evt.velocityY,
-          clamp: [0, headerHeight.value!],
+          velocity: -event.velocityY,
+          clamp: [0, headerScrollDistance.value],
+          deceleration: IS_IOS ? 0.998 : 0.99,
         },
-        () => {
+        (finished) => {
           isSlidingTopContainer.value = false
+          isTopContainerOutOfSync.value = finished
         }
       )
     },
   })
 
+  //Keeps updating the active tab scroll as we scroll on the top container element
   useAnimatedReaction(
     () => scrollYCurrent.value - contentInset.value,
     (nextPosition, previousPosition) => {
       if (nextPosition !== previousPosition && isSlidingTopContainer.value) {
-        scrollToImpl(
-          refMap[tabNames.value[index.value]],
-          0,
-          scrollYCurrent.value - contentInset.value,
-          false
-        )
+        syncActiveTabScroll(nextPosition)
+        onScroll()
       }
+    }
+  )
+
+  /* Syncs the scroll of the active tab once we complete the scroll gesture 
+  on the header and the decay animation completes with success
+   */
+  useAnimatedReaction(
+    () => {
+      return (
+        isSlidingTopContainer.value !== isSlidingTopContainerPrev.value &&
+        isTopContainerOutOfSync.value
+      )
+    },
+    (result) => {
+      isSlidingTopContainerPrev.value = isSlidingTopContainer.value
+
+      if (!result) return
+      if (isSlidingTopContainer.value === true) return
+
+      syncActiveTabScroll(scrollYCurrent.value - contentInset.value)
+      onScroll()
+      tryToSnap()
+
+      isTopContainerOutOfSync.value = false
     }
   )
 

--- a/src/TopContainer.tsx
+++ b/src/TopContainer.tsx
@@ -1,0 +1,131 @@
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import {
+  PanGestureHandler,
+  PanGestureHandlerGestureEvent,
+} from 'react-native-gesture-handler'
+import Animated, {
+  useAnimatedStyle,
+  Extrapolate,
+  interpolate,
+  useAnimatedGestureHandler,
+  withDecay,
+  useAnimatedReaction,
+} from 'react-native-reanimated'
+
+import { scrollToImpl } from './helpers'
+import { useTabsContext } from './hooks'
+import { CollapsibleProps } from './types'
+
+type TabBarContainerProps = Pick<
+  CollapsibleProps,
+  'headerContainerStyle' | 'cancelTranslation'
+>
+
+export const TopContainer: React.FC<TabBarContainerProps> = ({
+  children,
+  headerContainerStyle,
+  cancelTranslation,
+}) => {
+  const {
+    headerTranslateY,
+    revealHeaderOnScroll,
+    isSlidingTopContainer,
+    scrollYCurrent,
+    headerHeight,
+    contentInset,
+    refMap,
+    tabNames,
+    index,
+  } = useTabsContext()
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          translateY: headerTranslateY.value,
+        },
+      ],
+    }
+  }, [revealHeaderOnScroll])
+
+  const gestureHandler = useAnimatedGestureHandler<
+    PanGestureHandlerGestureEvent,
+    { startY: number }
+  >({
+    onActive: (event, ctx) => {
+      if (!isSlidingTopContainer.value) {
+        ctx.startY = scrollYCurrent.value
+        isSlidingTopContainer.value = true
+
+        return
+      }
+
+      scrollYCurrent.value = interpolate(
+        -event.translationY + ctx.startY,
+        [0, headerHeight.value!],
+        [0, headerHeight.value!],
+        Extrapolate.CLAMP
+      )
+    },
+    onEnd: (evt, ctx) => {
+      if (!isSlidingTopContainer.value) return
+
+      ctx.startY = 0
+      scrollYCurrent.value = withDecay(
+        {
+          velocity: -evt.velocityY,
+          clamp: [0, headerHeight.value!],
+        },
+        () => {
+          isSlidingTopContainer.value = false
+        }
+      )
+    },
+  })
+
+  useAnimatedReaction(
+    () => scrollYCurrent.value - contentInset.value,
+    (nextPosition, previousPosition) => {
+      if (nextPosition !== previousPosition && isSlidingTopContainer.value) {
+        scrollToImpl(
+          refMap[tabNames.value[index.value]],
+          0,
+          scrollYCurrent.value - contentInset.value,
+          false
+        )
+      }
+    }
+  )
+
+  return (
+    <PanGestureHandler onGestureEvent={gestureHandler}>
+      <Animated.View
+        style={[
+          styles.container,
+          headerContainerStyle,
+          !cancelTranslation && animatedStyles,
+        ]}
+      >
+        {children}
+      </Animated.View>
+    </PanGestureHandler>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    zIndex: 100,
+    width: '100%',
+    backgroundColor: 'white',
+    shadowColor: '#000000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.23,
+    shadowRadius: 2.62,
+    elevation: 4,
+  },
+})

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -258,6 +258,7 @@ export const useScrollHandlerY = (name: TabName) => {
     contentHeights,
     indexDecimal,
     allowHeaderOverscroll,
+    isSlidingHeader,
   } = useTabsContext()
 
   const enabled = useSharedValue(false)
@@ -365,7 +366,7 @@ export const useScrollHandlerY = (name: TabName) => {
   const scrollHandler = useAnimatedScrollHandler(
     {
       onScroll: (event) => {
-        if (!enabled.value) return
+        if (!enabled.value || isSlidingHeader.value) return
 
         if (focusedTab.value === name) {
           if (IS_IOS) {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -258,7 +258,7 @@ export const useScrollHandlerY = (name: TabName) => {
     contentHeights,
     indexDecimal,
     allowHeaderOverscroll,
-    isSlidingHeader,
+    isSlidingTopContainer,
   } = useTabsContext()
 
   const enabled = useSharedValue(false)
@@ -366,7 +366,7 @@ export const useScrollHandlerY = (name: TabName) => {
   const scrollHandler = useAnimatedScrollHandler(
     {
       onScroll: (event) => {
-        if (!enabled.value || isSlidingHeader.value) return
+        if (!enabled.value || isSlidingTopContainer.value) return
 
         if (focusedTab.value === name) {
           if (IS_IOS) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,6 +225,7 @@ export type ContextType<T extends TabName = TabName> = {
    */
   scrollX: Animated.SharedValue<number>
   isGliding: Animated.SharedValue<boolean>
+  isSlidingHeader: Animated.SharedValue<boolean>
   isSnapping: Animated.SharedValue<boolean>
   /**
    * The next snapping value, used only with diffClamp.

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type TabBarProps<T extends TabName = TabName> = {
   containerRef: React.RefObject<ContainerRef>
   onTabPress: (name: T) => void
   tabProps: TabsWithProps<T>
+  width?: number
 }
 
 export type IndexChangeEventData<T extends TabName = TabName> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,7 +226,7 @@ export type ContextType<T extends TabName = TabName> = {
    */
   scrollX: Animated.SharedValue<number>
   isGliding: Animated.SharedValue<boolean>
-  isSlidingHeader: Animated.SharedValue<boolean>
+  isSlidingTopContainer: Animated.SharedValue<boolean>
   isSnapping: Animated.SharedValue<boolean>
   /**
    * The next snapping value, used only with diffClamp.


### PR DESCRIPTION
The idea of the PR is to allow the header to contain Touchable elements and horizontal views that don't affect the vertical scroll behaviour of the tab view, this means we don't have to manually add pointerEvents to all views that are not target of the touch events, it also means we can have both the behaviours, having the element being target of a touch event as press and still be able to scroll vertically on the same element.

Improvements that need to be made:
- Changing tab when the header is scrolling is not perfect yet
- Further test reveal header on scroll and snapping
- Improve snapping, at the moment the snap only happens at the end of the decay which takes a bit too long in terms of UX, haven't tested it yet, but I believe one solution could be handling the snap logic on the onScrollEnd end event

Also, as mentioned on the feature request, I'm not sure if I missed any of the project internals that could introduce new bugs.

https://user-images.githubusercontent.com/17684951/166218485-9ae0f41b-7b44-45f0-8ff8-ab28a15aa719.mp4


