### PR TITLE
Fix/ios min height

### DIFF
--- a/example/src/MinHeaderHeight.tsx
+++ b/example/src/MinHeaderHeight.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
+import { Tabs } from 'react-native-collapsible-tab-view'
 
-import ExampleComponent from './Shared/ExampleComponent'
+import Albums from './Shared/Albums'
+import Contacts from './Shared/Contacts'
 import { buildHeader, HEADER_HEIGHT } from './Shared/Header'
+import SectionContacts from './Shared/SectionContacts'
 import { ExampleComponentType } from './types'
 
 const title = 'Min Header Height'
@@ -11,7 +14,21 @@ const minHeaderHeight = Math.round(HEADER_HEIGHT / 3)
 
 const DefaultExample: ExampleComponentType = () => {
   return (
-    <ExampleComponent renderHeader={Header} minHeaderHeight={minHeaderHeight} />
+    <Tabs.Container
+      headerHeight={HEADER_HEIGHT}
+      renderHeader={Header}
+      minHeaderHeight={minHeaderHeight}
+    >
+      <Tabs.Tab name="albums" label="Albums">
+        <Albums numberOfAlbums={2} />
+      </Tabs.Tab>
+      <Tabs.Tab name="contacts" label="Contacts">
+        <Contacts />
+      </Tabs.Tab>
+      <Tabs.Tab name="ordered" label="Ordered">
+        <SectionContacts />
+      </Tabs.Tab>
+    </Tabs.Container>
   )
 }
 

--- a/example/src/Shared/Albums.tsx
+++ b/example/src/Shared/Albums.tsx
@@ -27,11 +27,17 @@ const albumsContent = (n = 8) =>
     <Image key={i} source={source} style={styles.cover} />
   ))
 
-export const AlbumsContent = () => {
-  return <View style={styles.content}>{albumsContent()}</View>
+interface AlbumsProps {
+  numberOfAlbums?: number
 }
 
-export const Albums: React.FC = () => {
+export const AlbumsContent: React.FC<AlbumsProps> = ({
+  numberOfAlbums = 8,
+}) => {
+  return <View style={styles.content}>{albumsContent(numberOfAlbums)}</View>
+}
+
+export const Albums: React.FC<AlbumsProps> = ({ numberOfAlbums }) => {
   const [isRefreshing, startRefreshing] = useRefresh()
 
   return (
@@ -42,7 +48,7 @@ export const Albums: React.FC = () => {
         <RefreshControl refreshing={isRefreshing} onRefresh={startRefreshing} />
       }
     >
-      <AlbumsContent />
+      <AlbumsContent numberOfAlbums={numberOfAlbums} />
     </Tabs.ScrollView>
   )
 }

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -361,6 +361,7 @@ export const Container = React.memo(
             accDiffClamp,
             indexDecimal,
             containerHeight,
+            minHeaderHeight,
             scrollYCurrent,
             scrollY,
             setRef,

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -135,20 +135,29 @@ export function useCollapsibleStyle(): CollapsibleStyle {
     containerHeight,
     width,
     allowHeaderOverscroll,
+    minHeaderHeight,
   } = useTabsContext()
   const [containerHeightVal, tabBarHeightVal, headerHeightVal] = [
     useConvertAnimatedToValue(containerHeight),
     useConvertAnimatedToValue(tabBarHeight),
     useConvertAnimatedToValue(headerHeight),
   ]
+
+  const containerHeightWithMinHeader = Math.max(
+    0,
+    (containerHeightVal ?? 0) - minHeaderHeight
+  )
+
+  console.log('containerHeightWithMinHeader', containerHeightWithMinHeader)
+
   return useMemo(
     () => ({
       style: { width },
       contentContainerStyle: {
         minHeight:
           IS_IOS && !allowHeaderOverscroll
-            ? (containerHeightVal || 0) - (tabBarHeightVal || 0)
-            : (containerHeightVal || 0) + (headerHeightVal || 0),
+            ? containerHeightWithMinHeader - (tabBarHeightVal || 0)
+            : containerHeightWithMinHeader + (headerHeightVal || 0),
         paddingTop:
           IS_IOS && !allowHeaderOverscroll
             ? 0
@@ -163,10 +172,10 @@ export function useCollapsibleStyle(): CollapsibleStyle {
     }),
     [
       allowHeaderOverscroll,
-      containerHeightVal,
       headerHeightVal,
       tabBarHeightVal,
       width,
+      containerHeightWithMinHeader,
     ]
   )
 }

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -148,8 +148,6 @@ export function useCollapsibleStyle(): CollapsibleStyle {
     (containerHeightVal ?? 0) - minHeaderHeight
   )
 
-  console.log('containerHeightWithMinHeader', containerHeightWithMinHeader)
-
   return useMemo(
     () => ({
       style: { width },

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,8 @@ export type ContextType<T extends TabName = TabName> = {
    * @default false
    */
   allowHeaderOverscroll?: boolean
+
+  minHeaderHeight: number
 }
 
 export type ScrollViewProps = ComponentProps<typeof Animated.ScrollView>


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/PedroBern/react-native-collapsible-tab-view/issues/246#issuecomment-1289400711), where the user is able to scroll down after the content ends, this was occurring because the minHeaderHeight value was not taken into consideration when calculating the min height for the view.

I also updated the min header height example to make it more easier to test this specific scenario