### PR TITLE
Fix compatibility issues with Reanimated v3

### DIFF
--- a/src/MaterialTabBar/TabItem.tsx
+++ b/src/MaterialTabBar/TabItem.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { StyleSheet, Pressable, Platform } from 'react-native'
 import Animated, {
+  Extrapolate,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated'
@@ -41,7 +42,7 @@ export const MaterialTabItem = <T extends TabName = string>(
         indexDecimal.value,
         [index - 1, index, index + 1],
         [inactiveOpacity, 1, inactiveOpacity],
-        Animated.Extrapolate.CLAMP
+        Extrapolate.CLAMP
       ),
       color:
         Math.abs(index - indexDecimal.value) < 0.5

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -175,6 +175,7 @@ export function useUpdateScrollViewContentSize({ name }: { name: TabName }) {
   const { tabNames, contentHeights } = useTabsContext()
   const setContentHeights = useCallback(
     (name: TabName, height: number) => {
+      'worklet';
       const tabIndex = tabNames.value.indexOf(name)
       contentHeights.value[tabIndex] = height
       contentHeights.value = [...contentHeights.value]


### PR DESCRIPTION
# What's Changed
Reanimated v3 has brought some breaking changes. Fortunately, the changes that affect this library are not too significant.

- `Animated.Extrapolate` is no longer available. Use `Extrapolate` import directly from `react-native-reanimated`.
- All functions passed into `runOnUI` has to be marked as a `'worklet'`.