### PR TITLE
fix: improve snap behavior by using scrollTo directly

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -286,17 +286,6 @@ export const useScrollHandlerY = (name: TabName) => {
 
   const scrollTo = useScroller()
 
-  const scrollAnimation = useSharedValue<number | undefined>(undefined)
-
-  useAnimatedReaction(
-    () => scrollAnimation.value,
-    (val) => {
-      if (val !== undefined) {
-        scrollTo(refMap[name], 0, val, false, '[useAnimatedReaction scroll]')
-      }
-    }
-  )
-
   const onMomentumEnd = () => {
     'worklet'
     if (!enabled.value) return
@@ -319,9 +308,13 @@ export const useScrollHandlerY = (name: TabName) => {
               accDiffClamp.value = withTiming(headerScrollDistance.value)
 
               if (scrollYCurrent.value < headerScrollDistance.value) {
-                scrollAnimation.value = scrollYCurrent.value
-                scrollAnimation.value = withTiming(headerScrollDistance.value)
-                //console.log('[${name}] sticky snap up')
+                scrollTo(
+                  refMap[name],
+                  0,
+                  headerScrollDistance.value,
+                  true,
+                  `[${name}] sticky snap up`
+                )
               }
             }
           } else {
@@ -335,15 +328,17 @@ export const useScrollHandlerY = (name: TabName) => {
         ) {
           // snap down
           snappingTo.value = 0
-          scrollAnimation.value = scrollYCurrent.value
-          scrollAnimation.value = withTiming(0)
-          //console.log('[${name}] snap down')
+          scrollTo(refMap[name], 0, 0, true, `[${name}] snap down`)
         } else if (scrollYCurrent.value <= headerScrollDistance.value) {
           // snap up
           snappingTo.value = headerScrollDistance.value
-          scrollAnimation.value = scrollYCurrent.value
-          scrollAnimation.value = withTiming(headerScrollDistance.value)
-          //console.log('[${name}] snap up')
+          scrollTo(
+            refMap[name],
+            0,
+            headerScrollDistance.value,
+            true,
+            `[${name}] snap up`
+          )
         }
       }
     }


### PR DESCRIPTION
When using Reanimated v3, the scrolling becomes choppy when `snapThreshold` is specified and the header is snapping to the nearest point.

This PR fixes this by using `scrollTo` directly with `animated` set to `true` instead of through `useAnimatedReaction`.

|Before|After|
|--|--|
|<video src="https://user-images.githubusercontent.com/1888212/226081054-51bf2d2a-4979-4041-b91d-2e06c61e3339.mp4"/>|<video src="https://user-images.githubusercontent.com/1888212/226081058-ff3fa13d-7e1e-4b9a-b097-1a33bd942fb8.mp4"/>|

