### PR TITLE
fix: indicator display for single tab

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,6 +32,7 @@ import RevealHeaderOnScroll from './RevealHeaderOnScroll'
 import RevealHeaderOnScrollSnap from './RevealHeaderOnScrollSnap'
 import ScrollOnHeader from './ScrollOnHeader'
 import ScrollableTabs from './ScrollableTabs'
+import SingleTab from './SingleTab'
 import Snap from './Snap'
 import StartOnSpecificTab from './StartOnSpecificTab'
 import UndefinedHeaderHeight from './UndefinedHeaderHeight'
@@ -61,6 +62,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   AnimatedHeader,
   AndroidSharedPullToRefresh,
   HeaderOverscrollExample,
+  SingleTab,
 ]
 
 const ExampleList: React.FC<object> = () => {

--- a/example/src/Shared/ExampleComponentFlashList.tsx
+++ b/example/src/Shared/ExampleComponentFlashList.tsx
@@ -13,18 +13,15 @@ import { HEADER_HEIGHT } from './Header'
 
 type Props = {
   emptyContacts?: boolean
-  hideArticleTab?: boolean
 } & Partial<CollapsibleProps>
 
 const Example = React.forwardRef<CollapsibleRef, Props>(
   ({ emptyContacts, ...props }, ref) => {
     return (
       <Tabs.Container ref={ref} headerHeight={HEADER_HEIGHT} lazy {...props}>
-        {props.hideArticleTab ? (
-          <Tabs.Tab name="article" label="Article">
-            <Article />
-          </Tabs.Tab>
-        ) : null}
+        <Tabs.Tab name="article" label="Article">
+          <Article />
+        </Tabs.Tab>
         <Tabs.Tab name="albums" label="Albums">
           <Albums />
         </Tabs.Tab>

--- a/example/src/Shared/ExampleComponentMasonryFlashList.tsx
+++ b/example/src/Shared/ExampleComponentMasonryFlashList.tsx
@@ -13,18 +13,15 @@ import { HEADER_HEIGHT } from './Header'
 
 type Props = {
   emptyContacts?: boolean
-  hideArticleTab?: boolean
 } & Partial<CollapsibleProps>
 
 const Example = React.forwardRef<CollapsibleRef, Props>(
   ({ emptyContacts, ...props }, ref) => {
     return (
       <Tabs.Container ref={ref} headerHeight={HEADER_HEIGHT} lazy {...props}>
-        {props.hideArticleTab ? (
-          <Tabs.Tab name="article" label="Article">
-            <Article />
-          </Tabs.Tab>
-        ) : null}
+        <Tabs.Tab name="article" label="Article">
+          <Article />
+        </Tabs.Tab>
         <Tabs.Tab name="albums" label="Albums">
           <Albums />
         </Tabs.Tab>

--- a/example/src/SingleTab.tsx
+++ b/example/src/SingleTab.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import { Tabs, MaterialTabBar } from 'react-native-collapsible-tab-view'
+
+import { ArticleContent } from './Shared/Article'
+import { HEADER_HEIGHT, buildHeader } from './Shared/Header'
+import { ExampleComponentType } from './types'
+
+const title = 'Single Tab'
+
+const Header = buildHeader(title)
+
+const SingleTabExample: ExampleComponentType = () => {
+  return (
+    <Tabs.Container
+      renderHeader={Header}
+      headerHeight={HEADER_HEIGHT}
+      renderTabBar={(props) => (
+        <MaterialTabBar
+          {...props}
+          scrollEnabled
+          contentContainerStyle={styles.padding}
+        />
+      )}
+    >
+      <Tabs.Tab name="article" label="Article">
+        <Tabs.ScrollView>
+          <ArticleContent />
+        </Tabs.ScrollView>
+      </Tabs.Tab>
+    </Tabs.Container>
+  )
+}
+
+SingleTabExample.title = title
+
+export default SingleTabExample
+
+const styles = StyleSheet.create({
+  padding: { paddingHorizontal: 30 },
+})

--- a/src/MaterialTabBar/Indicator.tsx
+++ b/src/MaterialTabBar/Indicator.tsx
@@ -19,19 +19,21 @@ const Indicator: React.FC<IndicatorProps> = ({
   const opacity = useSharedValue(fadeIn ? 0 : 1)
 
   const stylez = useAnimatedStyle(() => {
-    const transform =
-      itemsLayout.length > 1
-        ? [
-            {
-              translateX: interpolate(
+    const transform = [
+      {
+        translateX:
+          itemsLayout.length > 1
+            ? interpolate(
                 indexDecimal.value,
                 itemsLayout.map((_, i) => i),
                 // when in RTL mode, the X value should be inverted
                 itemsLayout.map((v) => (isRTL ? -1 * v.x : v.x))
-              ),
-            },
-          ]
-        : undefined
+              )
+            : isRTL
+              ? -1 * itemsLayout[0]?.x
+              : itemsLayout[0]?.x,
+      },
+    ]
 
     const width =
       itemsLayout.length > 1

--- a/src/MaterialTabBar/Indicator.tsx
+++ b/src/MaterialTabBar/Indicator.tsx
@@ -19,6 +19,8 @@ const Indicator: React.FC<IndicatorProps> = ({
   const opacity = useSharedValue(fadeIn ? 0 : 1)
 
   const stylez = useAnimatedStyle(() => {
+    const firstItemX = itemsLayout[0]?.x ?? 0
+
     const transform = [
       {
         translateX:
@@ -30,8 +32,8 @@ const Indicator: React.FC<IndicatorProps> = ({
                 itemsLayout.map((v) => (isRTL ? -1 * v.x : v.x))
               )
             : isRTL
-              ? -1 * itemsLayout[0]?.x
-              : itemsLayout[0]?.x,
+              ? -1 * firstItemX
+              : firstItemX,
       },
     ]
 


### PR DESCRIPTION
In my app I added some container style with padding to have a specific display for the tabs. When there is only one tab, the indicator is not shifted accordingly. This is due to the `itemsLayout.length > 1` condition and the `undefined` value of `transform`. The same way as it's done for the `width`, I changed the `transform` to match the first item of the `itemsLayout` array if there is only one tab.

<table>
<tr>
 <th> Before
 <th> After
<tr>
 <td> <img src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/5436545/dd08ac8d-89ce-44c2-9366-384fa9cd483c">
 <td> <img src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/5436545/d168c162-0cd8-4237-b5fa-5198d7af76ba">
</table>

