### PR TITLE
refactor(container,lazy,hooks): avoid blocking JS thread by refactoring SharedValue.value access

### DIFF
--- a/example/src/AnimatedHeader.tsx
+++ b/example/src/AnimatedHeader.tsx
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],

--- a/example/src/FlashList.tsx
+++ b/example/src/FlashList.tsx
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],

--- a/example/src/MasonryFlashList.tsx
+++ b/example/src/MasonryFlashList.tsx
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],

--- a/example/src/Shared/Contacts.tsx
+++ b/example/src/Shared/Contacts.tsx
@@ -101,11 +101,7 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(
-      -top.value,
-      [0, height.value || 0],
-      [-(height.value || 0) / 2, 0]
-    )
+    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
   }, [height])
 
   const stylez = useAnimatedStyle(() => {

--- a/example/src/Shared/ContactsFlashList.tsx
+++ b/example/src/Shared/ContactsFlashList.tsx
@@ -101,11 +101,7 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(
-      -top.value,
-      [0, height.value || 0],
-      [-(height.value || 0) / 2, 0]
-    )
+    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
   }, [height])
 
   const stylez = useAnimatedStyle(() => {

--- a/example/src/Shared/ExampleMasonry.tsx
+++ b/example/src/Shared/ExampleMasonry.tsx
@@ -69,11 +69,7 @@ const ItemSeparator = () => <View style={styles.separator} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(
-      -top.value,
-      [0, height.value || 0],
-      [-(height.value || 0) / 2, 0]
-    )
+    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
   }, [height])
 
   const stylez = useAnimatedStyle(() => {

--- a/example/src/Shared/SectionContacts.tsx
+++ b/example/src/Shared/SectionContacts.tsx
@@ -117,11 +117,7 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(
-      -top.value,
-      [0, height.value || 0],
-      [-(height.value || 0) / 2, 0]
-    )
+    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
   }, [height])
 
   const stylez = useAnimatedStyle(() => {

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -11,7 +11,6 @@ import Animated, {
 import {
   useChainCallback,
   useCollapsibleStyle,
-  useConvertAnimatedToValue,
   useScrollHandlerY,
   useSharedAnimatedRef,
   useTabNameContext,
@@ -118,16 +117,14 @@ function FlashListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const contentInsetValue = useConvertAnimatedToValue<number>(contentInset)
-
   const memoContentInset = React.useMemo(
-    () => ({ top: contentInsetValue }),
-    [contentInsetValue]
+    () => ({ top: contentInset }),
+    [contentInset]
   )
 
   const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInsetValue }),
-    [contentInsetValue]
+    () => ({ x: 0, y: -contentInset }),
+    [contentInset]
   )
 
   const memoContentContainerStyle = React.useMemo(

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -6,7 +6,6 @@ import {
   useAfterMountEffect,
   useChainCallback,
   useCollapsibleStyle,
-  useConvertAnimatedToValue,
   useScrollHandlerY,
   useSharedAnimatedRef,
   useTabNameContext,
@@ -79,16 +78,14 @@ function FlatListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const contentInsetValue = useConvertAnimatedToValue(contentInset)
-
   const memoContentInset = React.useMemo(
-    () => ({ top: contentInsetValue }),
-    [contentInsetValue]
+    () => ({ top: contentInset }),
+    [contentInset]
   )
 
   const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInsetValue }),
-    [contentInsetValue]
+    () => ({ x: 0, y: -contentInset }),
+    [contentInset]
   )
 
   const memoContentContainerStyle = React.useMemo(

--- a/src/Lazy.tsx
+++ b/src/Lazy.tsx
@@ -38,15 +38,6 @@ export const Lazy: React.FC<{
   const { focusedTab, refMap } = useTabsContext()
 
   /**
-   * We start mounted if we are the focused tab, or if props.startMounted is true.
-   */
-  const startMounted = useSharedValue(
-    typeof _startMounted === 'boolean'
-      ? _startMounted
-      : focusedTab.value === name
-  )
-
-  /**
    * We keep track of whether a layout has been triggered
    */
   const didTriggerLayout = useSharedValue(false)
@@ -54,13 +45,24 @@ export const Lazy: React.FC<{
   /**
    * This is used to control when children are mounted
    */
-  const [canMount, setCanMount] = React.useState(!!startMounted.value)
+  const [canMount, setCanMount] = React.useState(false)
   /**
    * Ensure we don't mount after the component has been unmounted
    */
   const isSelfMounted = React.useRef(true)
 
-  const opacity = useSharedValue(cancelLazyFadeIn || startMounted.value ? 1 : 0)
+  /**
+   * We start mounted if we are the focused tab, or if props.startMounted is true.
+   */
+  const shouldStartMounted =
+    typeof _startMounted === 'boolean'
+      ? _startMounted
+      : focusedTab.value === name
+  let initialOpacity = 1
+  if (!cancelLazyFadeIn && !shouldStartMounted) {
+    initialOpacity = 0
+  }
+  const opacity = useSharedValue(initialOpacity)
 
   React.useEffect(() => {
     return () => {

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -8,7 +8,6 @@ import Animated, {
 import {
   useChainCallback,
   useCollapsibleStyle,
-  useConvertAnimatedToValue,
   useScrollHandlerY,
   useSharedAnimatedRef,
   useTabNameContext,
@@ -121,16 +120,14 @@ function MasonryFlashListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const contentInsetValue = useConvertAnimatedToValue<number>(contentInset)
-
   const memoContentInset = React.useMemo(
-    () => ({ top: contentInsetValue }),
-    [contentInsetValue]
+    () => ({ top: contentInset }),
+    [contentInset]
   )
 
   const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInsetValue }),
-    [contentInsetValue]
+    () => ({ x: 0, y: -contentInset }),
+    [contentInset]
   )
 
   const memoContentContainerStyle = React.useMemo(

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -6,7 +6,6 @@ import {
   useAfterMountEffect,
   useChainCallback,
   useCollapsibleStyle,
-  useConvertAnimatedToValue,
   useScrollHandlerY,
   useSharedAnimatedRef,
   useTabNameContext,
@@ -91,16 +90,14 @@ export const ScrollView = React.forwardRef<
       [progressViewOffset, refreshControl]
     )
 
-    const contentInsetValue = useConvertAnimatedToValue(contentInset)
-
     const memoContentInset = React.useMemo(
-      () => ({ top: contentInsetValue }),
-      [contentInsetValue]
+      () => ({ top: contentInset }),
+      [contentInset]
     )
 
     const memoContentOffset = React.useMemo(
-      () => ({ x: 0, y: -contentInsetValue }),
-      [contentInsetValue]
+      () => ({ x: 0, y: -contentInset }),
+      [contentInset]
     )
 
     const memoContentContainerStyle = React.useMemo(

--- a/src/SectionList.tsx
+++ b/src/SectionList.tsx
@@ -6,7 +6,6 @@ import {
   useAfterMountEffect,
   useChainCallback,
   useCollapsibleStyle,
-  useConvertAnimatedToValue,
   useScrollHandlerY,
   useSharedAnimatedRef,
   useTabNameContext,
@@ -86,16 +85,14 @@ function SectionListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const contentInsetValue = useConvertAnimatedToValue(contentInset)
-
   const memoContentInset = React.useMemo(
-    () => ({ top: contentInsetValue }),
-    [contentInsetValue]
+    () => ({ top: contentInset }),
+    [contentInset]
   )
 
   const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInsetValue }),
-    [contentInsetValue]
+    () => ({ x: 0, y: -contentInset }),
+    [contentInset]
   )
 
   const memoContentContainerStyle = React.useMemo(

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -22,7 +22,6 @@ import Animated, {
   interpolate,
   runOnJS,
   runOnUI,
-  useDerivedValue,
   useEvent,
   useHandler,
   AnimatedRef,
@@ -119,6 +118,20 @@ export function useTabNameContext(): TabName {
   return c
 }
 
+export function useLayoutHeight(initialHeight: number = 0) {
+  const [height, setHeight] = useState(initialHeight)
+
+  const getHeight = useCallback(
+    (event: LayoutChangeEvent) => {
+      const latestHeight = event.nativeEvent.layout.height
+      if (latestHeight !== height) {
+        setHeight(latestHeight)
+      }
+    },
+    [height, setHeight]
+  )
+  return [height, getHeight] as const
+}
 /**
  * Hook to access some key styles that make the whole thing work.
  *
@@ -133,15 +146,9 @@ export function useCollapsibleStyle(): CollapsibleStyle {
     allowHeaderOverscroll,
     minHeaderHeight,
   } = useTabsContext()
-  const [containerHeightVal, tabBarHeightVal, headerHeightVal] = [
-    useConvertAnimatedToValue(containerHeight),
-    useConvertAnimatedToValue(tabBarHeight),
-    useConvertAnimatedToValue(headerHeight),
-  ]
-
   const containerHeightWithMinHeader = Math.max(
     0,
-    (containerHeightVal ?? 0) - minHeaderHeight
+    (containerHeight ?? 0) - minHeaderHeight
   )
 
   return useMemo(
@@ -150,24 +157,24 @@ export function useCollapsibleStyle(): CollapsibleStyle {
       contentContainerStyle: {
         minHeight:
           IS_IOS && !allowHeaderOverscroll
-            ? containerHeightWithMinHeader - (tabBarHeightVal || 0)
-            : containerHeightWithMinHeader + (headerHeightVal || 0),
+            ? containerHeightWithMinHeader - (tabBarHeight || 0)
+            : containerHeightWithMinHeader + (headerHeight || 0),
         paddingTop:
           IS_IOS && !allowHeaderOverscroll
             ? 0
-            : (headerHeightVal || 0) + (tabBarHeightVal || 0),
+            : (headerHeight || 0) + (tabBarHeight || 0),
       },
       progressViewOffset:
         // on iOS we need the refresh control to be at the top if overscrolling
         IS_IOS && allowHeaderOverscroll
           ? 0
           : // on android we need it below the header or it doesn't show because of z-index
-            (headerHeightVal || 0) + (tabBarHeightVal || 0),
+            (headerHeight || 0) + (tabBarHeight || 0),
     }),
     [
       allowHeaderOverscroll,
-      headerHeightVal,
-      tabBarHeightVal,
+      headerHeight,
+      tabBarHeight,
       width,
       containerHeightWithMinHeader,
     ]
@@ -231,9 +238,9 @@ export function useScroller<T extends RefComponent>() {
       if (!ref) return
       //! this is left here on purpose to ease troubleshooting (uncomment when necessary)
       // console.log(
-      //   `${_debugKey}, y: ${y}, y adjusted: ${y - contentInset.value}`
+      //   `${_debugKey}, y: ${y}, y adjusted: ${y - contentInset}`
       // )
-      scrollToImpl(ref, x, y - contentInset.value, animated)
+      scrollToImpl(ref, x, y - contentInset, animated)
     },
     [contentInset]
   )
@@ -272,15 +279,8 @@ export const useScrollHandlerY = (name: TabName) => {
     (toggle: boolean) => {
       'worklet'
       enabled.value = toggle
-
-      if (toggle) {
-        const ref = refMap[name]
-        const y = scrollY.value[name] ?? scrollYCurrent.value
-
-        scrollTo(ref, 0, y, false, `[${name}] restore scroll position - enable`)
-      }
     },
-    [enabled, name, refMap, scrollTo, scrollY.value, scrollYCurrent.value]
+    [name, refMap, scrollTo]
   )
 
   /**
@@ -290,11 +290,6 @@ export const useScrollHandlerY = (name: TabName) => {
    * call it to sync the scenes.
    */
   const afterDrag = useSharedValue(0)
-
-  const tabIndex = useMemo(
-    () => tabNames.value.findIndex((n) => n === name),
-    [tabNames, name]
-  )
 
   const scrollAnimation = useSharedValue<number | undefined>(undefined)
 
@@ -359,11 +354,6 @@ export const useScrollHandlerY = (name: TabName) => {
     }
   }
 
-  const contentHeight = useDerivedValue(() => {
-    const tabIndex = tabNames.value.indexOf(name)
-    return contentHeights.value[tabIndex] || Number.MAX_VALUE
-  }, [])
-
   const scrollHandler = useAnimatedScrollHandler(
     {
       onScroll: (event) => {
@@ -373,11 +363,14 @@ export const useScrollHandlerY = (name: TabName) => {
           if (IS_IOS) {
             let { y } = event.contentOffset
             // normalize the value so it starts at 0
-            y = y + contentInset.value
+            y = y + contentInset
+
+            const contentHeight =
+              contentHeights.value[tabNames.value.indexOf(name)] ||
+              Number.MAX_VALUE
+
             const clampMax =
-              contentHeight.value -
-              (containerHeight.value || 0) +
-              contentInset.value
+              contentHeight - (containerHeight || 0) + contentInset
             // make sure the y value is clamped to the scrollable size (clamps overscrolling)
             scrollYCurrent.value = allowHeaderOverscroll
               ? y
@@ -498,7 +491,7 @@ export const useScrollHandlerY = (name: TabName) => {
             if (focusedIsOnTop) {
               nextPosition = snappingTo.value
             } else if (currIsOnTop) {
-              nextPosition = headerHeight.value || 0
+              nextPosition = headerHeight || 0
             }
           } else if (currIsOnTop || focusedIsOnTop) {
             nextPosition = Math.min(focusedScrollY, headerScrollDistance.value)
@@ -512,7 +505,7 @@ export const useScrollHandlerY = (name: TabName) => {
         }
       }
     },
-    [revealHeaderOnScroll, refMap, snapThreshold, tabIndex, enabled, scrollTo]
+    [revealHeaderOnScroll, refMap, snapThreshold, enabled, scrollTo]
   )
 
   return { scrollHandler, enable }
@@ -586,7 +579,7 @@ export function useAfterMountEffect(
 export function useConvertAnimatedToValue<T>(
   animatedValue: Animated.SharedValue<T>
 ) {
-  const [value, setValue] = useState(animatedValue.value)
+  const [value, setValue] = useState<T>(animatedValue.value)
 
   useAnimatedReaction(
     () => {
@@ -600,7 +593,7 @@ export function useConvertAnimatedToValue<T>(
     [value]
   )
 
-  return value
+  return value || 0
 }
 
 export interface HeaderMeasurements {
@@ -611,7 +604,7 @@ export interface HeaderMeasurements {
   /**
    * Animated value that represents the height of the header
    */
-  height: Animated.SharedValue<number | undefined>
+  height: number
 }
 
 export function useHeaderMeasurements(): HeaderMeasurements {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,8 +135,9 @@ export type CollapsibleProps = {
 }
 
 export type ContextType<T extends TabName = TabName> = {
-  headerHeight: SharedValue<number | undefined>
-  tabBarHeight: SharedValue<number | undefined>
+  headerHeight: number
+  tabBarHeight: number
+  containerHeight: number
   revealHeaderOnScroll: boolean
   snapThreshold: number | null | undefined
   /**
@@ -169,7 +170,6 @@ export type ContextType<T extends TabName = TabName> = {
    * Array of the scroll y position of each tab.
    */
   scrollY: SharedValue<Record<string, number>>
-  containerHeight: SharedValue<number | undefined>
   /**
    * Object containing the ref of each scrollable component.
    */
@@ -209,7 +209,7 @@ export type ContextType<T extends TabName = TabName> = {
    */
   contentHeights: SharedValue<number[]>
 
-  contentInset: SharedValue<number>
+  contentInset: number
 
   headerTranslateY: SharedValue<number>
 


### PR DESCRIPTION
Hey  @andreialecu  and @gkartalis (tagging bc I can't add reviewers), I was introducing this library to solve a UI pattern and noticed blocking JavaScript thread behavior that caused a regression of over 500ms to our initial screen render. 

<img width="800" alt="cpu-profile-of-collapsible-tab-view" src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/548a5b44-f037-44ce-ad27-57c376d2bd88">

The flame graph above shows that the JavaScript thread is blocked by executeOnUIRuntimeSync for quite some time impacting the initial render time of a screen by over 500ms.

On closer analysis I found that the problem is caused by reading a SharedValue.value in the main JS thread. This library does this quite often in places that could avoid it. This PR refactors most of the places where it does not need to be a SharedValue while trying to not cause any regressions.

I understand there isn't unit or e2e tests for this library so I tried my best to test the Example app. I posted multiple recordings below of how it currently works with these changes.

[I also wrote a detailed blogpost explaining this Reanimated blocking behavior](https://andrei-calazans.com/posts/reanimated-blocking-js-thread/).

You can also inspect the before and after CPU profilings, [I stored them here](https://gist.github.com/AndreiCalazans/3fc4a522f94ea3387060f9c6fe461840/revisions). The CPU profile will show that before these changes there were 57 calls to executeOnUIRuntimeSync when navigating from the main menu to the FlashList example in the Example app and now there are only 14 calls.

| Before (57 calls) | After (14 calls) |
|--|--|
| <img width="600" alt="image" src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/fbb2510f-21b9-402e-86fb-2b2c21892d46"> | <img width="600" alt="image" src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/d9f4b860-bd2a-4ea5-b3fd-407636e9e52a"> |


## Demos

| One | Two |
|--|--|
| <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/1f688b19-a427-428d-8fb8-0141d7f862ab"/> | <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/6b1b8e30-a7b9-4459-b83a-2175df02b4cc"/>  |

| Three | Four |
|--|--|
| <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/fd42dc3a-ef9b-4647-8d0e-3ab3eea26a24"/> | <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/40b58e5e-20a4-49e7-b357-0675da0d0cff"/>  |

| Five | Six |
|--|--|
| <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/ac4e036f-a7f0-47bc-b824-ce7411b69bb5"/> | <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/779df616-5b09-4d18-8f1a-79bcb6ae5eba"/>  |


| Seven | Eight |
|--|--|
| <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/130b7eaf-6245-4cdb-9451-e6e8f4256889"/> | <video src="https://github.com/PedroBern/react-native-collapsible-tab-view/assets/20777666/8615933a-4e99-4026-8b1f-5a9338150602"/>  |
