### PR TITLE
chore(e2e): create basic e2e script

### DIFF
--- a/e2e.yaml
+++ b/e2e.yaml
@@ -1,0 +1,20 @@
+appId: com.rnctvexample 
+---
+- launchApp
+- tapOn: .*FlashList.*
+- assertVisible: "Scroll Y is: 0.00"
+- swipe:
+    direction: UP
+    duration: 300
+- swipe:
+    direction: LEFT
+    duration: 150
+- swipe:
+    direction: LEFT
+    duration: 150
+- swipe:
+    direction: UP
+    duration: 150
+- swipe:
+    direction: UP
+    duration: 150

--- a/perf_test.sh
+++ b/perf_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Error: deviceId is not defined."
+  exit 1
+fi
+
+deviceId="$1"
+appId="com.rnctvexample"
+
+echo "Testing $appId"
+
+flashlight test --bundleId $appId \
+  --testCommand "maestro --device $deviceId test -e APP_ID=$appId e2e.yaml" \
+  --iterationCount 10 \
+  --resultsTitle $appId \
+  --resultsFilePath $appId.json
+
+adb -s $deviceId shell am force-stop $appId
+adb -s $deviceId shell pm clear $appId
+sleep 0.2
+
+version_report_files=$(printf " %s.json" "${versions[@]}")
+flashlight report$version_report_files


### PR DESCRIPTION
Scripts plus e2e tests using Maestro to facilate performance regression testing. It's intended only for Android.

It uses Flashlight with Maestro, steps for usage:

- [Install Flashlight](https://docs.flashlight.dev/)
- [Install Maestro](https://maestro.mobile.dev/getting-started/installing-maestro) install version 1.29.0 since that's the one comaptible with Flashlight (`export MAESTRO_VERSION=1.29.0; curl -Ls "https://get.maestro.mobile.dev" | bash`)
- Get your device ID (adb devices)
- Run script ./test.sh <DEVICE_ID>