### PR TITLE
refactor!: use shared values for scroll enhancements, `contentInset`

### DIFF
--- a/example/src/AnimatedHeader.tsx
+++ b/example/src/AnimatedHeader.tsx
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],

--- a/example/src/FlashList.tsx
+++ b/example/src/FlashList.tsx
@@ -10,18 +10,18 @@ import Animated, {
 import ExampleComponent from './Shared/ExampleComponentFlashList'
 import ReText from './Shared/ReText'
 import { ExampleComponentType } from './types'
-import { useCurrentTabScrollY } from '../../src/hooks'
+import { useCurrentTabScrollY, useTabsContext } from '../../src/hooks'
 
 const title = 'FlashList (contacts tab)'
 
 const MIN_HEADER_HEIGHT = 48
 
 export const Header = () => {
+  const { contentInset } = useTabsContext()
   const { top, height } = useHeaderMeasurements()
   const scrollY = useCurrentTabScrollY()
-
   const scrollYText = useDerivedValue(
-    () => `Scroll Y is: ${scrollY.value.toFixed(2)}`
+    () => `${contentInset.value.toFixed(2)} ${scrollY.value.toFixed(2)}`
   )
 
   const stylez = useAnimatedStyle(() => {
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],
@@ -50,7 +50,6 @@ export const Header = () => {
 const Example: ExampleComponentType = () => {
   return (
     <ExampleComponent
-      allowHeaderOverscroll
       renderHeader={() => <Header />}
       minHeaderHeight={MIN_HEADER_HEIGHT}
     />

--- a/example/src/MasonryFlashList.tsx
+++ b/example/src/MasonryFlashList.tsx
@@ -30,8 +30,8 @@ export const Header = () => {
         {
           translateY: interpolate(
             top.value,
-            [0, -(height || 0 - MIN_HEADER_HEIGHT)],
-            [0, (height || 0 - MIN_HEADER_HEIGHT) / 2]
+            [0, -(height.value || 0 - MIN_HEADER_HEIGHT)],
+            [0, (height.value || 0 - MIN_HEADER_HEIGHT) / 2]
           ),
         },
       ],

--- a/example/src/Shared/Contacts.tsx
+++ b/example/src/Shared/Contacts.tsx
@@ -101,8 +101,12 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
-  }, [height])
+    return interpolate(
+      -top.value,
+      [0, height.value || 0],
+      [-(height.value || 0) / 2, 0]
+    )
+  }, [])
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/example/src/Shared/ContactsFlashList.tsx
+++ b/example/src/Shared/ContactsFlashList.tsx
@@ -101,8 +101,13 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
-  }, [height])
+    'worklet'
+    return interpolate(
+      -top.value,
+      [0, height.value || 0],
+      [-(height.value || 0) / 2, 0]
+    )
+  }, [])
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/example/src/Shared/ExampleMasonry.tsx
+++ b/example/src/Shared/ExampleMasonry.tsx
@@ -69,8 +69,12 @@ const ItemSeparator = () => <View style={styles.separator} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
-  }, [height])
+    return interpolate(
+      -top.value,
+      [0, height.value || 0],
+      [-(height.value || 0) / 2, 0]
+    )
+  }, [])
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/example/src/Shared/SectionContacts.tsx
+++ b/example/src/Shared/SectionContacts.tsx
@@ -117,8 +117,12 @@ const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />
 const ListEmptyComponent = () => {
   const { top, height } = Tabs.useHeaderMeasurements()
   const translateY = useDerivedValue(() => {
-    return interpolate(-top.value, [0, height || 0], [-(height || 0) / 2, 0])
-  }, [height])
+    return interpolate(
+      -top.value,
+      [0, height.value || 0],
+      [-(height.value || 0) / 2, 0]
+    )
+  }, [])
 
   const stylez = useAnimatedStyle(() => {
     return {

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -106,13 +106,15 @@ export const Container = React.memo(
         [initialTabName, tabNamesArray]
       )
 
-      const contentInset = React.useMemo(() => {
+      const contentInset = useDerivedValue(() => {
         if (allowHeaderOverscroll) return 0
 
         // necessary for the refresh control on iOS to be positioned underneath the header
         // this also adjusts the scroll bars to clamp underneath the header area
-        return IS_IOS ? (headerHeight || 0) + (tabBarHeight || 0) : 0
-      }, [headerHeight, tabBarHeight, allowHeaderOverscroll])
+        return IS_IOS
+          ? (headerHeight.value || 0) + (tabBarHeight.value || 0)
+          : 0
+      }, [allowHeaderOverscroll])
 
       const snappingTo: ContextType['snappingTo'] = useSharedValue(0)
       const offset: ContextType['offset'] = useSharedValue(0)
@@ -141,8 +143,10 @@ export const Container = React.memo(
       const calculateNextOffset = useSharedValue(initialIndex)
       const headerScrollDistance: ContextType['headerScrollDistance'] =
         useDerivedValue(() => {
-          return headerHeight !== undefined ? headerHeight - minHeaderHeight : 0
-        }, [headerHeight, minHeaderHeight])
+          return headerHeight.value !== undefined
+            ? headerHeight.value - minHeaderHeight
+            : 0
+        }, [minHeaderHeight])
 
       const indexDecimal: ContextType['indexDecimal'] = useSharedValue(
         index.value
@@ -162,7 +166,7 @@ export const Container = React.memo(
           scrollToImpl(
             refMap[name],
             0,
-            scrollYCurrent.value - contentInset,
+            scrollYCurrent.value - contentInset.value,
             false
           )
         }
@@ -179,7 +183,7 @@ export const Container = React.memo(
             resyncTabScroll()
           }
         },
-        [tabNamesArray, refMap, afterRender, contentInset]
+        [tabNamesArray, refMap, afterRender]
       )
 
       // derived from scrollX
@@ -215,7 +219,7 @@ export const Container = React.memo(
         scrollToImpl(
           refMap[name],
           0,
-          scrollYCurrent.value - contentInset,
+          scrollYCurrent.value - contentInset.value,
           false
         )
       }
@@ -299,7 +303,7 @@ export const Container = React.memo(
             runOnUI(scrollToImpl)(
               ref,
               0,
-              headerScrollDistance.value - contentInset,
+              headerScrollDistance.value - contentInset.value,
               true
             )
           } else {
@@ -307,7 +311,7 @@ export const Container = React.memo(
           }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [containerRef, refMap, contentInset]
+        [containerRef, refMap]
       )
 
       useAnimatedReaction(

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -6,6 +6,7 @@ import React, { useCallback } from 'react'
 import Animated, {
   useSharedValue,
   useAnimatedReaction,
+  useAnimatedProps,
 } from 'react-native-reanimated'
 
 import {
@@ -117,22 +118,19 @@ function FlashListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const memoContentInset = React.useMemo(
-    () => ({ top: contentInset }),
-    [contentInset]
-  )
-
-  const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInset }),
-    [contentInset]
-  )
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      contentInset: { top: contentInset.value },
+      contentOffset: { x: 0, y: -contentInset.value },
+    }
+  }, [])
 
   const memoContentContainerStyle = React.useMemo(
     () => ({
       paddingTop: contentContainerStyle.paddingTop,
       ..._contentContainerStyle,
     }),
-    [_contentContainerStyle, contentContainerStyle.paddingTop]
+    [_contentContainerStyle, contentContainerStyle]
   )
 
   const refWorkaround = useCallback(
@@ -157,8 +155,7 @@ function FlashListImpl<R>(
       bouncesZoom={false}
       onScroll={scrollHandler}
       scrollEventThrottle={16}
-      contentInset={memoContentInset}
-      contentOffset={memoContentOffset}
+      animatedProps={animatedProps}
       refreshControl={memoRefreshControl}
       progressViewOffset={progressViewOffset}
       automaticallyAdjustContentInsets={false}

--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -7,6 +7,7 @@ import Animated, {
   useSharedValue,
   useAnimatedReaction,
   useAnimatedProps,
+  AnimatedProps,
 } from 'react-native-reanimated'
 
 import {
@@ -19,15 +20,17 @@ import {
   useUpdateScrollViewContentSize,
 } from './hooks'
 
+type AnimatedFlatListProps = AnimatedProps<FlashListProps<unknown>>
+
 /**
  * Used as a memo to prevent rerendering too often when the context changes.
  * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
  */
 
-type FlashListMemoProps = React.PropsWithChildren<FlashListProps<unknown>>
+type FlashListMemoProps = React.PropsWithChildren<AnimatedFlatListProps>
 type FlashListMemoRef = SPFlashList<any>
 
-let AnimatedFlashList: React.ComponentClass<FlashListProps<any>> | null = null
+let AnimatedFlashList: React.ComponentClass<AnimatedFlatListProps> | null = null
 
 const ensureFlastList = () => {
   if (AnimatedFlashList) {
@@ -38,7 +41,7 @@ const ensureFlastList = () => {
     const flashListModule = require('@shopify/flash-list')
     AnimatedFlashList = Animated.createAnimatedComponent(
       flashListModule.FlashList
-    ) as unknown as React.ComponentClass<FlashListProps<any>>
+    ) as unknown as React.ComponentClass<AnimatedFlatListProps>
   } catch {
     console.error(
       'The optional dependency @shopify/flash-list is not installed. Please install it to use the FlashList component.'

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { FlatList as RNFlatList, FlatListProps } from 'react-native'
-import { useAnimatedProps } from 'react-native-reanimated'
+import { AnimatedProps, useAnimatedProps } from 'react-native-reanimated'
 
 import { AnimatedFlatList } from './helpers'
 import {
@@ -14,12 +14,14 @@ import {
   useUpdateScrollViewContentSize,
 } from './hooks'
 
+type AnimatedFlatListProps = AnimatedProps<FlatListProps<unknown>>
+
 /**
  * Used as a memo to prevent rerendering too often when the context changes.
  * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
  */
 const FlatListMemo = React.memo(
-  React.forwardRef<RNFlatList, React.PropsWithChildren<FlatListProps<unknown>>>(
+  React.forwardRef<RNFlatList, React.PropsWithChildren<AnimatedFlatListProps>>(
     (props, passRef) => {
       return <AnimatedFlatList ref={passRef} {...props} />
     }

--- a/src/FlatList.tsx
+++ b/src/FlatList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FlatList as RNFlatList, FlatListProps } from 'react-native'
+import { useAnimatedProps } from 'react-native-reanimated'
 
 import { AnimatedFlatList } from './helpers'
 import {
@@ -78,15 +79,12 @@ function FlatListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const memoContentInset = React.useMemo(
-    () => ({ top: contentInset }),
-    [contentInset]
-  )
-
-  const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInset }),
-    [contentInset]
-  )
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      contentInset: { top: contentInset.value },
+      contentOffset: { x: 0, y: -contentInset.value },
+    }
+  }, [])
 
   const memoContentContainerStyle = React.useMemo(
     () => [
@@ -111,8 +109,7 @@ function FlatListImpl<R>(
       onScroll={scrollHandler}
       onContentSizeChange={scrollContentSizeChangeHandlers}
       scrollEventThrottle={16}
-      contentInset={memoContentInset}
-      contentOffset={memoContentOffset}
+      animatedProps={animatedProps}
       automaticallyAdjustContentInsets={false}
       refreshControl={memoRefreshControl}
       // workaround for: https://github.com/software-mansion/react-native-reanimated/issues/2735

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -1,6 +1,7 @@
 import { MasonryFlashListProps, MasonryFlashListRef } from '@shopify/flash-list'
 import React, { useCallback } from 'react'
 import Animated, {
+  AnimatedProps,
   useAnimatedProps,
   useAnimatedReaction,
   useSharedValue,
@@ -16,18 +17,16 @@ import {
   useUpdateScrollViewContentSize,
 } from './hooks'
 
+type AnimatedFlatListProps = AnimatedProps<MasonryFlashListProps<unknown>>
+
 /**
  * Used as a memo to prevent rerendering too often when the context changes.
  * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
  */
-
-type MasonryFlashListMemoProps = React.PropsWithChildren<
-  MasonryFlashListProps<unknown>
->
+type MasonryFlashListMemoProps = React.PropsWithChildren<AnimatedFlatListProps>
 type MasonryFlashListMemoRef = MasonryFlashListRef<any>
 
-let AnimatedMasonry: React.ComponentClass<MasonryFlashListProps<any>> | null =
-  null
+let AnimatedMasonry: React.ComponentClass<AnimatedFlatListProps> | null = null
 
 const ensureMasonry = () => {
   if (AnimatedMasonry) {
@@ -38,7 +37,7 @@ const ensureMasonry = () => {
     const flashListModule = require('@shopify/flash-list')
     AnimatedMasonry = Animated.createAnimatedComponent(
       flashListModule.MasonryFlashList
-    ) as unknown as React.ComponentClass<MasonryFlashListProps<any>>
+    ) as unknown as React.ComponentClass<AnimatedFlatListProps>
   } catch {
     console.error(
       'The optional dependency @shopify/flash-list is not installed. Please install it to use the FlashList component.'

--- a/src/MasonryFlashList.tsx
+++ b/src/MasonryFlashList.tsx
@@ -1,6 +1,7 @@
 import { MasonryFlashListProps, MasonryFlashListRef } from '@shopify/flash-list'
 import React, { useCallback } from 'react'
 import Animated, {
+  useAnimatedProps,
   useAnimatedReaction,
   useSharedValue,
 } from 'react-native-reanimated'
@@ -120,15 +121,12 @@ function MasonryFlashListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const memoContentInset = React.useMemo(
-    () => ({ top: contentInset }),
-    [contentInset]
-  )
-
-  const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInset }),
-    [contentInset]
-  )
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      contentInset: { top: contentInset.value },
+      contentOffset: { x: 0, y: -contentInset.value },
+    }
+  }, [])
 
   const memoContentContainerStyle = React.useMemo(
     () => ({
@@ -160,8 +158,7 @@ function MasonryFlashListImpl<R>(
       bouncesZoom={false}
       onScroll={scrollHandler}
       scrollEventThrottle={16}
-      contentInset={memoContentInset}
-      contentOffset={memoContentOffset}
+      animatedProps={animatedProps}
       refreshControl={memoRefreshControl}
       progressViewOffset={progressViewOffset}
       automaticallyAdjustContentInsets={false}

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { ScrollViewProps, ScrollView as RNScrollView } from 'react-native'
-import Animated, { useAnimatedProps } from 'react-native-reanimated'
+import Animated, {
+  AnimatedProps,
+  useAnimatedProps,
+} from 'react-native-reanimated'
 
 import {
   useAfterMountEffect,
@@ -13,22 +16,25 @@ import {
   useUpdateScrollViewContentSize,
 } from './hooks'
 
+type AnimatedScrollViewProps = AnimatedProps<ScrollViewProps>
+
 /**
  * Used as a memo to prevent rerendering too often when the context changes.
  * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
  */
 const ScrollViewMemo = React.memo(
-  React.forwardRef<RNScrollView, React.PropsWithChildren<ScrollViewProps>>(
-    (props, passRef) => {
-      return (
-        <Animated.ScrollView
-          // @ts-expect-error reanimated types are broken on ref
-          ref={passRef}
-          {...props}
-        />
-      )
-    }
-  )
+  React.forwardRef<
+    RNScrollView,
+    React.PropsWithChildren<AnimatedScrollViewProps>
+  >((props, passRef) => {
+    return (
+      <Animated.ScrollView
+        // @ts-expect-error reanimated types are broken on ref
+        ref={passRef}
+        {...props}
+      />
+    )
+  })
 )
 
 /**

--- a/src/ScrollView.tsx
+++ b/src/ScrollView.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ScrollViewProps, ScrollView as RNScrollView } from 'react-native'
-import Animated from 'react-native-reanimated'
+import Animated, { useAnimatedProps } from 'react-native-reanimated'
 
 import {
   useAfterMountEffect,
@@ -90,15 +90,12 @@ export const ScrollView = React.forwardRef<
       [progressViewOffset, refreshControl]
     )
 
-    const memoContentInset = React.useMemo(
-      () => ({ top: contentInset }),
-      [contentInset]
-    )
-
-    const memoContentOffset = React.useMemo(
-      () => ({ x: 0, y: -contentInset }),
-      [contentInset]
-    )
+    const animatedProps = useAnimatedProps(() => {
+      return {
+        contentInset: { top: contentInset.value },
+        contentOffset: { x: 0, y: -contentInset.value },
+      }
+    }, [])
 
     const memoContentContainerStyle = React.useMemo(
       () => [
@@ -121,8 +118,7 @@ export const ScrollView = React.forwardRef<
         onScroll={scrollHandler}
         onContentSizeChange={scrollContentSizeChangeHandlers}
         scrollEventThrottle={16}
-        contentInset={memoContentInset}
-        contentOffset={memoContentOffset}
+        animatedProps={animatedProps}
         automaticallyAdjustContentInsets={false}
         refreshControl={memoRefreshControl}
         // workaround for: https://github.com/software-mansion/react-native-reanimated/issues/2735

--- a/src/SectionList.tsx
+++ b/src/SectionList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { SectionList as RNSectionList, SectionListProps } from 'react-native'
+import { useAnimatedProps } from 'react-native-reanimated'
 
 import { AnimatedSectionList } from './helpers'
 import {
@@ -85,15 +86,12 @@ function SectionListImpl<R>(
     [progressViewOffset, refreshControl]
   )
 
-  const memoContentInset = React.useMemo(
-    () => ({ top: contentInset }),
-    [contentInset]
-  )
-
-  const memoContentOffset = React.useMemo(
-    () => ({ x: 0, y: -contentInset }),
-    [contentInset]
-  )
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      contentInset: { top: contentInset.value },
+      contentOffset: { x: 0, y: -contentInset.value },
+    }
+  }, [])
 
   const memoContentContainerStyle = React.useMemo(
     () => [
@@ -118,8 +116,7 @@ function SectionListImpl<R>(
       onScroll={scrollHandler}
       onContentSizeChange={scrollContentSizeChangeHandlers}
       scrollEventThrottle={16}
-      contentInset={memoContentInset}
-      contentOffset={memoContentOffset}
+      animatedProps={animatedProps}
       automaticallyAdjustContentInsets={false}
       refreshControl={memoRefreshControl}
       // workaround for: https://github.com/software-mansion/react-native-reanimated/issues/2735

--- a/src/SectionList.tsx
+++ b/src/SectionList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { SectionList as RNSectionList, SectionListProps } from 'react-native'
-import { useAnimatedProps } from 'react-native-reanimated'
+import { AnimatedProps, useAnimatedProps } from 'react-native-reanimated'
 
 import { AnimatedSectionList } from './helpers'
 import {
@@ -14,6 +14,8 @@ import {
   useUpdateScrollViewContentSize,
 } from './hooks'
 
+type AnimatedSectionListProps = AnimatedProps<SectionListProps<unknown>>
+
 /**
  * Used as a memo to prevent rerendering too often when the context changes.
  * See: https://github.com/facebook/react/issues/15156#issuecomment-474590693
@@ -21,7 +23,7 @@ import {
 const SectionListMemo = React.memo(
   React.forwardRef<
     RNSectionList,
-    React.PropsWithChildren<SectionListProps<unknown>>
+    React.PropsWithChildren<AnimatedSectionListProps>
   >((props, passRef) => {
     return (
       <AnimatedSectionList

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -28,7 +28,6 @@ import Animated, {
   Extrapolation,
   useDerivedValue,
   SharedValue,
-  useAnimatedProps,
 } from 'react-native-reanimated'
 import { useDeepCompareMemo } from 'use-deep-compare'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,9 +135,9 @@ export type CollapsibleProps = {
 }
 
 export type ContextType<T extends TabName = TabName> = {
-  headerHeight: number
-  tabBarHeight: number
-  containerHeight: number
+  headerHeight: SharedValue<number>
+  tabBarHeight: SharedValue<number>
+  containerHeight: SharedValue<number>
   revealHeaderOnScroll: boolean
   snapThreshold: number | null | undefined
   /**
@@ -209,7 +209,7 @@ export type ContextType<T extends TabName = TabName> = {
    */
   contentHeights: SharedValue<number[]>
 
-  contentInset: number
+  contentInset: SharedValue<number>
 
   headerTranslateY: SharedValue<number>
 


### PR DESCRIPTION
Thank you so much for creating this amazing library.

In my working environment, the header size changes dynamically. However, when using `<Tabs.FlashList />` or `<Tabs.FlatList />`, I noticed that the `contentInset` is state, causing sudden changes where the `RefreshControl` appears on the first screen even when it `refreshing` field is set to false.

To address this issue, I’ve refactored the `contentInset` to use Reanimated’s SharedValue, allowing it to work dynamically and adapt to the changing content inset.