### PR TITLE
Fix flashlist not rendering on android

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -433,7 +433,7 @@ export const Container = React.memo(
             >
               {data.map((tabName, i) => {
                 return (
-                  <View key={i}>
+                  <View key={i} style={{ height: '100%', width: '100%' }}>
                     <TabNameContext.Provider value={tabName}>
                       <Lazy
                         startMounted={lazy ? undefined : true}


### PR DESCRIPTION
Related to #448, but also uses version 6.2.1. Any version after this has buggy/laggy scrolling on iOS when re-renders occur. This issue needs to be documented.