### PR TITLE
fix: horizontal scrolling back to 0 on load

### DIFF
--- a/src/MaterialTabBar/TabBar.tsx
+++ b/src/MaterialTabBar/TabBar.tsx
@@ -100,19 +100,22 @@ const MaterialTabBar = <T extends TabName = TabName>({
         if (!event.nativeEvent?.layout) return
         const { width, x } = event.nativeEvent.layout
 
-        itemLayoutGathering.current.set(name, {
-          width,
-          x,
-        })
+        // Only update if we don't already have a layout for this tab
+        if (!itemLayoutGathering.current.has(name)) {
+          itemLayoutGathering.current.set(name, {
+            width,
+            x,
+          })
 
-        // pick out the layouts for the tabs we know about (in case they changed dynamically)
-        const layout = Array.from(itemLayoutGathering.current.entries())
-          .filter(([tabName]) => tabNames.includes(tabName))
-          .map(([, layout]) => layout)
-          .sort((a, b) => a.x - b.x)
+          // pick out the layouts for the tabs we know about (in case they changed dynamically)
+          const layout = Array.from(itemLayoutGathering.current.entries())
+            .filter(([tabName]) => tabNames.includes(tabName))
+            .map(([, layout]) => layout)
+            .sort((a, b) => a.x - b.x)
 
-        if (layout.length === tabNames.length) {
-          setItemsLayout(layout)
+          if (layout.length === tabNames.length) {
+            setItemsLayout(layout)
+          }
         }
       }
     },


### PR DESCRIPTION
For TabViews where scrollEnabled is set to true and a tab that is off-screen is selected, if that tab has async content, the horizontal scroll position of the tab bar was resetting to the start once the content was loaded.  Just added a check to only update  the layout if we don't already have a layout for the selected tab