### PR TITLE
fix: new arch flickering

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -229,7 +229,10 @@ export const Container = React.memo(
       const toggleSyncScrollFrame = (toggle: boolean) =>
         syncScrollFrame.setActive(toggle)
       const syncScrollFrame = useFrameCallback(({ timeSinceFirstFrame }) => {
-        syncCurrentTabScrollPosition()
+        if (timeSinceFirstFrame % 100 === 0) {
+          syncCurrentTabScrollPosition()
+        }
+
         if (timeSinceFirstFrame > 1500) {
           runOnJS(toggleSyncScrollFrame)(false)
         }


### PR DESCRIPTION
## Description

This part of code is trying to scroll view in every frame for 1500ms which means hundreds of operations, before new architecture it was working fine, but it seems now with new architecture it causes problems when you switch tabs. I just added simple condition so it will scroll only every 100ms, so much less operations and it seems fine with this fix.