### PR TITLE
fix: pass full contentContainerStyle in FlashList wrapper (Android minHeight)

### DIFF
--- a/src/FlashList.tsx
+++ b/src/FlashList.tsx
@@ -129,10 +129,10 @@ function FlashListImpl<R>(
 
   const memoContentContainerStyle = React.useMemo(
     () => ({
-      paddingTop: contentContainerStyle.paddingTop,
+      ...contentContainerStyle,
       ..._contentContainerStyle,
     }),
-    [_contentContainerStyle, contentContainerStyle.paddingTop]
+    [_contentContainerStyle, contentContainerStyle]
   )
 
   const refWorkaround = useCallback(


### PR DESCRIPTION
## Summary

`FlashList.tsx` only extracted `paddingTop` from the library's calculated `contentContainerStyle`, dropping `minHeight`. This caused Android scroll sync to fail on tab switch when content was shorter than the viewport.

The fix spreads the full `contentContainerStyle` (matching `FlatList.tsx` behavior), ensuring the library's calculated `minHeight` reaches the FlashList.

### Root Cause

`useCollapsibleStyle()` calculates `minHeight: containerHeight + headerScrollDistance` to ensure content is tall enough for Android's scroll sync. `FlatList.tsx` passes this through correctly, but `FlashList.tsx` only extracted `paddingTop`:

```tsx
// Before (FlashList.tsx) — drops minHeight:
() => ({
  paddingTop: contentContainerStyle.paddingTop,
  ..._contentContainerStyle,
})

// After — matches FlatList.tsx behavior:
() => ({
  ...contentContainerStyle,
  ..._contentContainerStyle,
})
```

Without `minHeight`, Android's `scrollTo(headerScrollDistance)` silently fails when tab content is shorter than the viewport, because the max scroll offset is less than the target. iOS is unaffected (uses native `contentInset`).

### Reproduction

1. Use `Tabs.FlashList` with 2+ tabs on Android
2. Have one tab with content shorter than the screen height
3. Scroll down until the header fully collapses
4. Switch to the short-content tab
5. **Expected:** Content appears immediately below the collapsed header
6. **Actual:** Large gap (~headerScrollDistance pixels) above the content

### Test plan

- [x] Android: Scroll down, switch to short-content tab — no gap
- [x] iOS: No regression — same behavior as before

fixes #498 